### PR TITLE
Disable Twig cache in debug mode

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -17,6 +17,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin as CorePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventManager;
+use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Plugin class for WyriHaximus\TwigView.
@@ -42,6 +43,10 @@ class Plugin extends BasePlugin
                 ]
             ));
             EventManager::instance()->on(new Event\ProfilerListener());
+        }
+
+        if (Configure::read('debug')) {
+            Configure::write(sprintf('%s.cache', TwigView::ENV_CONFIG), false);
         }
     }
 }


### PR DESCRIPTION
This PR resolves #249 

In `Plugin::bootstrap()` the Twig cache is disabled if debug is active. Since test of `Plugin` class was missing I don't have done any test.

Let me know if you want a test case for this or if I am out of the way or if the right place to set it was `TwigView` instead.