### PR TITLE
5.1 - Moved to Cake\TwigView namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require wyrihaximus/twig-view
 Run the following CLI command:
 
 ```sh
-bin/cake plugin load WyriHaximus/TwigView
+bin/cake plugin load Cake/TwigView
 ```
 
 ### Use View class
@@ -32,7 +32,7 @@ Instead of extending from the `View` let `AppView` extend `TwigView`:
 ```php
 namespace App\View;
 
-use WyriHaximus\TwigView\View\TwigView;
+use Cake\TwigView\View\TwigView;
 
 class AppView extends TwigView
 {
@@ -283,15 +283,15 @@ This plugin emits several events.
 
 ### Loaders ###
 
-The default loader can be replace by listening to the `WyriHaximus\TwigView\Event\LoaderEvent::EVENT`, for example with [twital](https://github.com/goetas/twital):
+The default loader can be replace by listening to the `Cake\TwigView\Event\LoaderEvent::EVENT`, for example with [twital](https://github.com/goetas/twital):
 
 ```php
 <?php
 
 use Cake\Event\EventListenerInterface;
 use Goetas\Twital\TwitalLoader;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\Event\LoaderEvent;
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\LoaderEvent;
 
 class LoaderListener implements EventListenerInterface
 {
@@ -324,13 +324,13 @@ class LoaderListener implements EventListenerInterface
 
 ### Extensions ###
 
-Extensions can be added to the twig environment by listening to the `WyriHaximus\TwigView\Event\ConstructEvent::EVENT`, for example:
+Extensions can be added to the twig environment by listening to the `Cake\TwigView\Event\ConstructEvent::EVENT`, for example:
 
 ```php
 <?php
 
 use Cake\Event\EventListenerInterface;
-use WyriHaximus\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\ConstructEvent;
 
 class LoaderListener implements EventListenerInterface
 {
@@ -357,7 +357,7 @@ You can use the following command to generate your index, add, edit and view fil
 using Twig :
 
 ```bash
-bin/cake bake twig_template Tasks all -t WyriHaximus/TwigView
+bin/cake bake twig_template Tasks all -t Cake/TwigView
 ```
 
 ## Screenshots ##

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,13 @@
     },
     "autoload": {
         "psr-4": {
+            "Cake\\TwigView\\": "src/",
             "WyriHaximus\\TwigView\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "WyriHaximus\\CakePHP\\Tests\\TwigView\\": "tests/",
+            "Cake\\TwigView\\Test\\": "tests/",
             "App\\": "tests/test_app/",
             "TestTwigView\\": "tests/test_app/Plugin/TestTwigView/src",
             "Modern\\": "tests/test_app/Plugin/Modern/src",

--- a/composer.lock
+++ b/composer.lock
@@ -3403,16 +3403,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f512001679f37e6a042b51897ed24a2f05eba656"
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f512001679f37e6a042b51897ed24a2f05eba656",
-                "reference": "f512001679f37e6a042b51897ed24a2f05eba656",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
                 "shasum": ""
             },
             "require": {
@@ -3475,11 +3475,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-25T12:44:29+00:00"
+            "time": "2020-02-24T13:10:00+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -3529,16 +3529,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "3a50be43515590faf812fbd7708200aabc327ec3"
+                "reference": "ea69c129aed9fdeca781d4b77eb20b62cf5d5357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/3a50be43515590faf812fbd7708200aabc327ec3",
-                "reference": "3a50be43515590faf812fbd7708200aabc327ec3",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ea69c129aed9fdeca781d4b77eb20b62cf5d5357",
+                "reference": "ea69c129aed9fdeca781d4b77eb20b62cf5d5357",
                 "shasum": ""
             },
             "require": {
@@ -3574,7 +3574,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-04T13:00:46+00:00"
+            "time": "2020-02-14T07:42:58+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -3636,16 +3636,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36"
+                "reference": "bf9166bac906c9e69fb7a11d94875e7ced97bcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f5697ab4cb14a5deed7473819e63141bf5352c36",
-                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36",
+                "url": "https://api.github.com/repos/symfony/process/zipball/bf9166bac906c9e69fb7a11d94875e7ced97bcd7",
+                "reference": "bf9166bac906c9e69fb7a11d94875e7ced97bcd7",
                 "shasum": ""
             },
             "require": {
@@ -3681,7 +3681,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-09T09:50:08+00:00"
+            "time": "2020-02-07T20:06:44+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2,17 +2,15 @@
 declare(strict_types=1);
 
 return [
-    'Cake' => [
-        'TwigView' => [
-            'environment' => [
-                // Anything you would pass into \Twig\Environment to overwrite the default settings, see: http://twig.sensiolabs.org/doc/api.html#environment-options
-            ],
-            'markdown' => [
-                'engine' => 'engine', // See https://twig.symfony.com/doc/3.x/filters/markdown_to_html.html and then set to `new DefaultMarkdown()`
-            ],
-            'flags' => [
-                'potentialDangerous' => false,
-            ],
+    'TwigView' => [
+        'environment' => [
+            // Anything you would pass into \Twig\Environment to overwrite the default settings, see: http://twig.sensiolabs.org/doc/api.html#environment-options
+        ],
+        'markdown' => [
+            'engine' => 'engine', // See https://twig.symfony.com/doc/3.x/filters/markdown_to_html.html and then set to `new DefaultMarkdown()`
+        ],
+        'flags' => [
+            'potentialDangerous' => false,
         ],
     ],
 ];

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 return [
-    'WyriHaximus' => [
+    'Cake' => [
         'TwigView' => [
             'environment' => [
                 // Anything you would pass into \Twig\Environment to overwrite the default settings, see: http://twig.sensiolabs.org/doc/api.html#environment-options

--- a/quickstart.md
+++ b/quickstart.md
@@ -3,7 +3,7 @@
 // src/View/AppView.php
 namespace App\View;
 
-use WyriHaximus\TwigView\View\TwigView;
+use Cake\TwigView\View\TwigView;
 
 class AppView extends TwigView
 {
@@ -16,7 +16,7 @@ class AppView extends TwigView
 // src/View/AppView.php
 namespace App\View;
 
-use WyriHaximus\TwigView\View\TwigView;
+use Cake\TwigView\View\TwigView;
 
 class AppView extends TwigView
 {

--- a/src/Event/ConstructEvent.php
+++ b/src/Event/ConstructEvent.php
@@ -10,18 +10,18 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Event\Event;
+use Cake\TwigView\View\TwigView;
 use Twig\Environment;
-use WyriHaximus\TwigView\View\TwigView;
 
 final class ConstructEvent extends Event
 {
     public const EVENT = 'TwigView.TwigView.construct';
 
     /**
-     * @param \WyriHaximus\TwigView\View\TwigView $twigView TwigView instance.
+     * @param \Cake\TwigView\View\TwigView $twigView TwigView instance.
      * @param \Twig\Environment $twig Twig environment instance.
      * @return static
      */
@@ -34,7 +34,7 @@ final class ConstructEvent extends Event
     }
 
     /**
-     * @return \WyriHaximus\TwigView\View\TwigView
+     * @return \Cake\TwigView\View\TwigView
      */
     public function getTwigView(): TwigView
     {
@@ -49,3 +49,7 @@ final class ConstructEvent extends Event
         return $this->getData()['twig'];
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\ConstructEvent', 'Wyrihaximus\TwigView\Event\ConstructEvent');
+// phpcs:enable

--- a/src/Event/EnvironmentConfigEvent.php
+++ b/src/Event/EnvironmentConfigEvent.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Event\Event;
 
@@ -55,3 +55,7 @@ final class EnvironmentConfigEvent extends Event
         return $this;
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\EnvironmentConfigEvent', 'Wyrihaximus\TwigView\Event\EnvironmentConfigEvent');
+// phpcs:enable

--- a/src/Event/ExtensionsListener.php
+++ b/src/Event/ExtensionsListener.php
@@ -70,10 +70,10 @@ final class ExtensionsListener implements EventListenerInterface
         $event->getTwig()->addExtension(new Extension\Inflector());
 
         if (
-            !Configure::check('Cake.TwigView.flags.potentialDangerous') ||
+            !Configure::check('TwigView.flags.potentialDangerous') ||
             (
-                Configure::check('Cake.TwigView.flags.potentialDangerous') &&
-                Configure::read('Cake.TwigView.flags.potentialDangerous') === true
+                Configure::check('TwigView.flags.potentialDangerous') &&
+                Configure::read('TwigView.flags.potentialDangerous') === true
             )
         ) {
             $event->getTwig()->addExtension(new Extension\PotentialDangerous());
@@ -81,10 +81,10 @@ final class ExtensionsListener implements EventListenerInterface
 
         // Markdown extension
         if (
-            Configure::check('Cake.TwigView.markdown.engine') &&
-            Configure::read('Cake.TwigView.markdown.engine') instanceof MarkdownInterface
+            Configure::check('TwigView.markdown.engine') &&
+            Configure::read('TwigView.markdown.engine') instanceof MarkdownInterface
         ) {
-            $engine = Configure::read('Cake.TwigView.markdown.engine');
+            $engine = Configure::read('TwigView.markdown.engine');
             $event->getTwig()->addExtension(new MarkdownExtension());
 
             $event->getTwig()->addRuntimeLoader(new class ($engine) implements RuntimeLoaderInterface {

--- a/src/Event/ExtensionsListener.php
+++ b/src/Event/ExtensionsListener.php
@@ -10,10 +10,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Core\Configure;
 use Cake\Event\EventListenerInterface;
+use Cake\TwigView\Lib\Twig\Extension;
 use Jasny\Twig\ArrayExtension;
 use Jasny\Twig\DateExtension;
 use Jasny\Twig\PcreExtension;
@@ -24,7 +25,6 @@ use Twig\Extra\Markdown\MarkdownExtension;
 use Twig\Extra\Markdown\MarkdownInterface;
 use Twig\Extra\Markdown\MarkdownRuntime;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
-use WyriHaximus\TwigView\Lib\Twig\Extension;
 
 /**
  * Class ExtensionsListener.
@@ -46,7 +46,7 @@ final class ExtensionsListener implements EventListenerInterface
     /**
      * Event handler.
      *
-     * @param \WyriHaximus\TwigView\Event\ConstructEvent $event Event.
+     * @param \Cake\TwigView\Event\ConstructEvent $event Event.
      * @return void
      */
     public function construct(ConstructEvent $event): void
@@ -70,10 +70,10 @@ final class ExtensionsListener implements EventListenerInterface
         $event->getTwig()->addExtension(new Extension\Inflector());
 
         if (
-            !Configure::check('WyriHaximus.TwigView.flags.potentialDangerous') ||
+            !Configure::check('Cake.TwigView.flags.potentialDangerous') ||
             (
-                Configure::check('WyriHaximus.TwigView.flags.potentialDangerous') &&
-                Configure::read('WyriHaximus.TwigView.flags.potentialDangerous') === true
+                Configure::check('Cake.TwigView.flags.potentialDangerous') &&
+                Configure::read('Cake.TwigView.flags.potentialDangerous') === true
             )
         ) {
             $event->getTwig()->addExtension(new Extension\PotentialDangerous());
@@ -81,10 +81,10 @@ final class ExtensionsListener implements EventListenerInterface
 
         // Markdown extension
         if (
-            Configure::check('WyriHaximus.TwigView.markdown.engine') &&
-            Configure::read('WyriHaximus.TwigView.markdown.engine') instanceof MarkdownInterface
+            Configure::check('Cake.TwigView.markdown.engine') &&
+            Configure::read('Cake.TwigView.markdown.engine') instanceof MarkdownInterface
         ) {
-            $engine = Configure::read('WyriHaximus.TwigView.markdown.engine');
+            $engine = Configure::read('Cake.TwigView.markdown.engine');
             $event->getTwig()->addExtension(new MarkdownExtension());
 
             $event->getTwig()->addRuntimeLoader(new class ($engine) implements RuntimeLoaderInterface {
@@ -124,3 +124,7 @@ final class ExtensionsListener implements EventListenerInterface
         // @codingStandardsIgnoreEnd
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\ExtensionsListener', 'Wyrihaximus\TwigView\Event\ExtensionsListener');
+// phpcs:enable

--- a/src/Event/LoaderEvent.php
+++ b/src/Event/LoaderEvent.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Event\Event;
 use Twig\Loader\LoaderInterface;
@@ -54,3 +54,7 @@ final class LoaderEvent extends Event
         return $this->getLoader();
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\LoaderEvent', 'Wyrihaximus\TwigView\Event\LoaderEvent');
+// phpcs:enable

--- a/src/Event/ProfileEvent.php
+++ b/src/Event/ProfileEvent.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Event\Event;
 use Twig\Profiler\Profile;
@@ -36,3 +36,7 @@ final class ProfileEvent extends Event
         return $this->getSubject();
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\ProfileEvent', 'Wyrihaximus\TwigView\Event\ProfileEvent');
+// phpcs:enable

--- a/src/Event/ProfilerListener.php
+++ b/src/Event/ProfilerListener.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
+use Cake\TwigView\Lib\Twig\Extension;
 use Twig\Profiler\Profile;
-use WyriHaximus\TwigView\Lib\Twig\Extension;
 
 /**
  * Class ExtensionsListener.
@@ -37,7 +37,7 @@ final class ProfilerListener implements EventListenerInterface
     /**
      * Event handler.
      *
-     * @param \WyriHaximus\TwigView\Event\ConstructEvent $event Event.
+     * @param \Cake\TwigView\Event\ConstructEvent $event Event.
      * @return void
      */
     public function construct(ConstructEvent $event): void
@@ -52,3 +52,7 @@ final class ProfilerListener implements EventListenerInterface
         EventManager::instance()->dispatch(ProfileEvent::create($profile));
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\ProfilerListener', 'Wyrihaximus\TwigView\Event\ProfilerListener');
+// phpcs:enable

--- a/src/Event/TokenParsersListener.php
+++ b/src/Event/TokenParsersListener.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Event;
+namespace Cake\TwigView\Event;
 
 use Cake\Event\EventListenerInterface;
+use Cake\TwigView\Lib\Twig\TokenParser;
 use LogicException;
-use WyriHaximus\TwigView\Lib\Twig\TokenParser;
 
 /**
  * Class TokenParsersListener.
@@ -36,7 +36,7 @@ final class TokenParsersListener implements EventListenerInterface
     /**
      * Event handler.
      *
-     * @param \WyriHaximus\TwigView\Event\ConstructEvent $event Event.
+     * @param \Cake\TwigView\Event\ConstructEvent $event Event.
      * @return void
      */
     public function construct(ConstructEvent $event): void
@@ -50,3 +50,7 @@ final class TokenParsersListener implements EventListenerInterface
         }
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Event\TokenParsersListener', 'Wyrihaximus\TwigView\Event\TokenParsersListener');
+// phpcs:enable

--- a/src/Lib/RelativeScanner.php
+++ b/src/Lib/RelativeScanner.php
@@ -8,6 +8,8 @@ use Cake\Core\Plugin;
 
 /**
  * Class RelativeScanner.
+ *
+ * @internal
  */
 final class RelativeScanner
 {

--- a/src/Lib/RelativeScanner.php
+++ b/src/Lib/RelativeScanner.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\TwigView\Lib;
+namespace Cake\TwigView\Lib;
 
 use Cake\Core\App;
 use Cake\Core\Plugin;

--- a/src/Lib/Scanner.php
+++ b/src/Lib/Scanner.php
@@ -14,6 +14,8 @@ use RegexIterator;
 
 /**
  * Class Scanner.
+ *
+ * @internal
  */
 final class Scanner
 {

--- a/src/Lib/Scanner.php
+++ b/src/Lib/Scanner.php
@@ -1,16 +1,16 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\TwigView\Lib;
+namespace Cake\TwigView\Lib;
 
 use Cake\Core\App;
 use Cake\Core\Plugin;
+use Cake\TwigView\View\TwigView;
 use FilesystemIterator;
 use Iterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class Scanner.

--- a/src/Lib/TreeScanner.php
+++ b/src/Lib/TreeScanner.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\TwigView\Lib;
+namespace Cake\TwigView\Lib;
 
 /**
  * Class TreeScanner.
- * @package WyriHaximus\TwigView\Lib
+ * @package Cake\TwigView\Lib
  */
 final class TreeScanner
 {

--- a/src/Lib/TreeScanner.php
+++ b/src/Lib/TreeScanner.php
@@ -5,6 +5,8 @@ namespace Cake\TwigView\Lib;
 
 /**
  * Class TreeScanner.
+ *
+ * @internal
  */
 final class TreeScanner
 {

--- a/src/Lib/Twig/Extension/Arrays.php
+++ b/src/Lib/Twig/Extension/Arrays.php
@@ -17,6 +17,8 @@ use Twig\TwigFunction;
 
 /**
  * Class Arrays.
+ *
+ * @internal
  */
 final class Arrays extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Arrays.php
+++ b/src/Lib/Twig/Extension/Arrays.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;

--- a/src/Lib/Twig/Extension/Basic.php
+++ b/src/Lib/Twig/Extension/Basic.php
@@ -17,6 +17,8 @@ use Twig\TwigFilter;
 
 /**
  * Class Basic.
+ *
+ * @internal
  */
 final class Basic extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Basic.php
+++ b/src/Lib/Twig/Extension/Basic.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Lib/Twig/Extension/I18n.php
+++ b/src/Lib/Twig/Extension/I18n.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;

--- a/src/Lib/Twig/Extension/I18n.php
+++ b/src/Lib/Twig/Extension/I18n.php
@@ -17,6 +17,8 @@ use Twig\TwigFunction;
 
 /**
  * Class I18n.
+ *
+ * @internal
  */
 final class I18n extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Inflector.php
+++ b/src/Lib/Twig/Extension/Inflector.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Lib/Twig/Extension/Inflector.php
+++ b/src/Lib/Twig/Extension/Inflector.php
@@ -17,6 +17,8 @@ use Twig\TwigFilter;
 
 /**
  * Class Inflector.
+ *
+ * @internal
  */
 final class Inflector extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Number.php
+++ b/src/Lib/Twig/Extension/Number.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Lib/Twig/Extension/Number.php
+++ b/src/Lib/Twig/Extension/Number.php
@@ -18,6 +18,8 @@ use Twig\TwigFunction;
 
 /**
  * Class Number.
+ *
+ * @internal
  */
 final class Number extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/PotentialDangerous.php
+++ b/src/Lib/Twig/Extension/PotentialDangerous.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Lib/Twig/Extension/PotentialDangerous.php
+++ b/src/Lib/Twig/Extension/PotentialDangerous.php
@@ -18,6 +18,8 @@ use Twig\TwigFunction;
 
 /**
  * Class Basic.
+ *
+ * @internal
  */
 class PotentialDangerous extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Profiler.php
+++ b/src/Lib/Twig/Extension/Profiler.php
@@ -18,6 +18,8 @@ use Twig\Profiler\Profile;
 
 /**
  * Class Basic.
+ *
+ * @internal
  */
 final class Profiler extends ProfilerExtension
 {

--- a/src/Lib/Twig/Extension/Profiler.php
+++ b/src/Lib/Twig/Extension/Profiler.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use DebugKit\DebugTimer;
 use Twig\Extension\ProfilerExtension;

--- a/src/Lib/Twig/Extension/Strings.php
+++ b/src/Lib/Twig/Extension/Strings.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Lib/Twig/Extension/Strings.php
+++ b/src/Lib/Twig/Extension/Strings.php
@@ -18,6 +18,8 @@ use Twig\TwigFunction;
 
 /**
  * Class Strings.
+ *
+ * @internal
  */
 final class Strings extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Time.php
+++ b/src/Lib/Twig/Extension/Time.php
@@ -18,6 +18,8 @@ use Twig\TwigFunction;
 
 /**
  * Class Time.
+ *
+ * @internal
  */
 final class Time extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/Time.php
+++ b/src/Lib/Twig/Extension/Time.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Cake\I18n\Time as CakeTime;
 use Twig\Extension\AbstractExtension;

--- a/src/Lib/Twig/Extension/Utils.php
+++ b/src/Lib/Twig/Extension/Utils.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Lib/Twig/Extension/Utils.php
+++ b/src/Lib/Twig/Extension/Utils.php
@@ -17,6 +17,8 @@ use Twig\TwigFilter;
 
 /**
  * Class Utils.
+ *
+ * @internal
  */
 final class Utils extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/View.php
+++ b/src/Lib/Twig/Extension/View.php
@@ -18,6 +18,8 @@ use Twig\TwigFunction;
 
 /**
  * Class View.
+ *
+ * @internal
  */
 final class View extends AbstractExtension
 {

--- a/src/Lib/Twig/Extension/View.php
+++ b/src/Lib/Twig/Extension/View.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Lib\Twig\Extension;
 
 use Cake\View\View as CakeView;
 use Twig\Extension\AbstractExtension;

--- a/src/Lib/Twig/Loader.php
+++ b/src/Lib/Twig/Loader.php
@@ -10,14 +10,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig;
+namespace Cake\TwigView\Lib\Twig;
 
 use Cake\Core\App;
 use Cake\Core\Plugin;
+use Cake\TwigView\View\TwigView;
 use Twig\Error\LoaderError;
 use Twig\Loader\LoaderInterface;
 use Twig\Source;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class Loader.

--- a/src/Lib/Twig/Loader.php
+++ b/src/Lib/Twig/Loader.php
@@ -21,6 +21,8 @@ use Twig\Source;
 
 /**
  * Class Loader.
+ *
+ * @internal
  */
 final class Loader implements LoaderInterface
 {

--- a/src/Lib/Twig/Node/Cell.php
+++ b/src/Lib/Twig/Node/Cell.php
@@ -20,6 +20,8 @@ use Twig\Node\NodeOutputInterface;
 
 /**
  * Class Cell.
+ *
+ * @internal
  */
 final class Cell extends Node implements NodeOutputInterface
 {

--- a/src/Lib/Twig/Node/Cell.php
+++ b/src/Lib/Twig/Node/Cell.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Node;
+namespace Cake\TwigView\Lib\Twig\Node;
 
 use Twig\Compiler;
 use Twig\Node\Expression\AbstractExpression;

--- a/src/Lib/Twig/Node/Element.php
+++ b/src/Lib/Twig/Node/Element.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\Node;
+namespace Cake\TwigView\Lib\Twig\Node;
 
 use Twig\Compiler;
 use Twig\Node\Expression\AbstractExpression;

--- a/src/Lib/Twig/Node/Element.php
+++ b/src/Lib/Twig/Node/Element.php
@@ -19,6 +19,8 @@ use Twig\Node\Node;
 
 /**
  * Class Element.
+ *
+ * @internal
  */
 final class Element extends Node
 {

--- a/src/Lib/Twig/TokenParser/Cell.php
+++ b/src/Lib/Twig/TokenParser/Cell.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\TokenParser;
+namespace Cake\TwigView\Lib\Twig\TokenParser;
 
+use Cake\TwigView\Lib\Twig\Node\Cell as CellNode;
 use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\IncludeTokenParser;
-use WyriHaximus\TwigView\Lib\Twig\Node\Cell as CellNode;
 
 /**
  * Class Element.

--- a/src/Lib/Twig/TokenParser/Cell.php
+++ b/src/Lib/Twig/TokenParser/Cell.php
@@ -19,6 +19,8 @@ use Twig\TokenParser\IncludeTokenParser;
 
 /**
  * Class Element.
+ *
+ * @internal
  */
 final class Cell extends IncludeTokenParser
 {

--- a/src/Lib/Twig/TokenParser/Element.php
+++ b/src/Lib/Twig/TokenParser/Element.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Lib\Twig\TokenParser;
+namespace Cake\TwigView\Lib\Twig\TokenParser;
 
+use Cake\TwigView\Lib\Twig\Node\Element as ElementNode;
 use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\IncludeTokenParser;
-use WyriHaximus\TwigView\Lib\Twig\Node\Element as ElementNode;
 
 /**
  * Class Element.

--- a/src/Lib/Twig/TokenParser/Element.php
+++ b/src/Lib/Twig/TokenParser/Element.php
@@ -19,6 +19,8 @@ use Twig\TokenParser\IncludeTokenParser;
 
 /**
  * Class Element.
+ *
+ * @internal
  */
 final class Element extends IncludeTokenParser
 {

--- a/src/Panel/TwigPanel.php
+++ b/src/Panel/TwigPanel.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\TwigView\Panel;
+namespace Cake\TwigView\Panel;
 
+use Cake\TwigView\Lib\TreeScanner;
 use DebugKit\DebugPanel;
-use WyriHaximus\TwigView\Lib\TreeScanner;
 
 final class TwigPanel extends DebugPanel
 {
@@ -13,7 +13,7 @@ final class TwigPanel extends DebugPanel
      *
      * @var string
      */
-    public $plugin = 'WyriHaximus/TwigView';
+    public $plugin = 'Cake/TwigView';
 
     /**
      * Get the data for the twig panel.
@@ -27,3 +27,7 @@ final class TwigPanel extends DebugPanel
         ];
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Panel\TwigPanel', 'Wyrihaximus\TwigView\Panel\TwigPanel');
+// phpcs:enable

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView;
+namespace Cake\TwigView;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
@@ -19,7 +19,7 @@ use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventManager;
 
 /**
- * Plugin class for WyriHaximus\TwigView.
+ * Plugin class for Cake\TwigView.
  */
 class Plugin extends BasePlugin
 {
@@ -38,10 +38,14 @@ class Plugin extends BasePlugin
             Configure::write('DebugKit.panels', array_merge(
                 (array)Configure::read('DebugKit.panels'),
                 [
-                    'WyriHaximus/TwigView.Twig',
+                    'Cake/TwigView.Twig',
                 ]
             ));
             EventManager::instance()->on(new Event\ProfilerListener());
         }
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Plugin', 'Wyrihaximus\TwigView\Plugin');
+// phpcs:enable

--- a/src/Shell/CompileShell.php
+++ b/src/Shell/CompileShell.php
@@ -10,25 +10,25 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Shell;
+namespace Cake\TwigView\Shell;
 
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\ORM\Locator\LocatorInterface;
-use WyriHaximus\TwigView\Lib\Scanner;
-use WyriHaximus\TwigView\View\TwigView;
+use Cake\TwigView\Lib\Scanner;
+use Cake\TwigView\View\TwigView;
 
 /**
  * Class CompileTemplatesShell.
- * @package WyriHaximus\TwigView\Console\Command
+ * @package Cake\TwigView\Console\Command
  */
 class CompileShell extends Shell
 {
     /**
      * Instance of TwigView to be used to compile templates.
      *
-     * @var \WyriHaximus\TwigView\View\TwigView
+     * @var \Cake\TwigView\View\TwigView
      */
     protected $twigView;
 
@@ -48,7 +48,7 @@ class CompileShell extends Shell
     /**
      * Set TwigView.
      *
-     * @param \WyriHaximus\TwigView\View\TwigView $twigView TwigView instance.
+     * @param \Cake\TwigView\View\TwigView $twigView TwigView instance.
      * @return void
      */
     public function setTwigview(TwigView $twigView)

--- a/src/Shell/Task/TwigTemplateTask.php
+++ b/src/Shell/Task/TwigTemplateTask.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\Shell\Task;
+namespace Cake\TwigView\Shell\Task;
 
 use Bake\Shell\Task\TemplateTask;
 use Cake\Console\Shell;

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -10,27 +10,27 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\TwigView\View;
+namespace Cake\TwigView\View;
 
 use Cake\Core\Configure;
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\EnvironmentConfigEvent;
+use Cake\TwigView\Event\LoaderEvent;
+use Cake\TwigView\Lib\Twig\Loader;
 use Cake\View\View;
 use Exception;
 use Twig\Environment;
 use Twig\Loader\LoaderInterface;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\Event\EnvironmentConfigEvent;
-use WyriHaximus\TwigView\Event\LoaderEvent;
-use WyriHaximus\TwigView\Lib\Twig\Loader;
 
 /**
  * Class TwigView.
- * @package WyriHaximus\TwigView\View
+ * @package Cake\TwigView\View
  */
 class TwigView extends View
 {
     public const EXT = '.twig';
 
-    public const ENV_CONFIG = 'WyriHaximus.TwigView.environment';
+    public const ENV_CONFIG = 'Cake.TwigView.environment';
 
     /**
      * Extension to use.
@@ -266,3 +266,7 @@ class TwigView extends View
         return false;
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\View\TwigView', 'Wyrihaximus\TwigView\View\TwigView');
+// phpcs:enable

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -29,7 +29,7 @@ class TwigView extends View
 {
     public const EXT = '.twig';
 
-    public const ENV_CONFIG = 'Cake.TwigView.environment';
+    public const ENV_CONFIG = 'TwigView.environment';
 
     /**
      * Extension to use.

--- a/tests/Event/ConstructEventTest.php
+++ b/tests/Event/ConstructEventTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Event;
+namespace Cake\TwigView\Test\Event;
 
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Test\TestCase;
+use Cake\TwigView\View\TwigView;
 use Twig\Environment;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\View\TwigView;
 
 class ConstructEventTest extends TestCase
 {

--- a/tests/Event/EnvironmentConfigEventTest.php
+++ b/tests/Event/EnvironmentConfigEventTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Event;
+namespace Cake\TwigView\Test\Event;
 
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Event\EnvironmentConfigEvent;
+use Cake\TwigView\Event\EnvironmentConfigEvent;
+use Cake\TwigView\Test\TestCase;
 
 class EnvironmentConfigEventTest extends TestCase
 {

--- a/tests/Event/ExtensionsListenerTest.php
+++ b/tests/Event/ExtensionsListenerTest.php
@@ -10,23 +10,23 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Event;
+namespace Cake\TwigView\Test\Event;
 
 use Cake\Core\Configure;
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\ExtensionsListener;
+use Cake\TwigView\Test\TestCase;
+use Cake\TwigView\View\TwigView;
 use Prophecy\Argument;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\StringLoaderExtension;
 use Twig\Extra\Markdown\MarkdownExtension;
 use Twig\Extra\Markdown\MarkdownInterface;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\Event\ExtensionsListener;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class ExtensionsListenerTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Event
+ * @package Cake\TwigView\Test\Event
  */
 class ExtensionsListenerTest extends TestCase
 {
@@ -50,7 +50,7 @@ class ExtensionsListenerTest extends TestCase
     public function testConstructMarkdownEngine()
     {
         Configure::write(
-            'WyriHaximus.TwigView.markdown.engine',
+            'Cake.TwigView.markdown.engine',
             $this->prophesize(MarkdownInterface::class)->reveal()
         );
 

--- a/tests/Event/ExtensionsListenerTest.php
+++ b/tests/Event/ExtensionsListenerTest.php
@@ -50,7 +50,7 @@ class ExtensionsListenerTest extends TestCase
     public function testConstructMarkdownEngine()
     {
         Configure::write(
-            'Cake.TwigView.markdown.engine',
+            'TwigView.markdown.engine',
             $this->prophesize(MarkdownInterface::class)->reveal()
         );
 

--- a/tests/Event/LoaderEventTest.php
+++ b/tests/Event/LoaderEventTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Event;
+namespace Cake\TwigView\Test\Event;
 
+use Cake\TwigView\Event\LoaderEvent;
+use Cake\TwigView\Lib\Twig\Loader;
+use Cake\TwigView\Test\TestCase;
 use Twig\Loader\LoaderInterface;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Event\LoaderEvent;
-use WyriHaximus\TwigView\Lib\Twig\Loader;
 
 class LoaderEventTest extends TestCase
 {

--- a/tests/Event/ProfilerListenerTest.php
+++ b/tests/Event/ProfilerListenerTest.php
@@ -10,18 +10,18 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Event;
+namespace Cake\TwigView\Test\Event;
 
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\ProfilerListener;
+use Cake\TwigView\Lib\Twig\Extension\Profiler;
+use Cake\TwigView\Test\TestCase;
+use Cake\TwigView\View\TwigView;
 use Twig\Environment;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\Event\ProfilerListener;
-use WyriHaximus\TwigView\Lib\Twig\Extension\Profiler;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class ProfilerListenerTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Event
+ * @package Cake\TwigView\Test\Event
  */
 class ProfilerListenerTest extends TestCase
 {

--- a/tests/Event/TokenParsersListenerTest.php
+++ b/tests/Event/TokenParsersListenerTest.php
@@ -10,19 +10,19 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Event;
+namespace Cake\TwigView\Test\Event;
 
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\TokenParsersListener;
+use Cake\TwigView\Test\TestCase;
+use Cake\TwigView\View\TwigView;
 use Prophecy\Argument;
 use Twig\Environment;
 use Twig\TokenParser\IncludeTokenParser;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\Event\TokenParsersListener;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class TokenParserListenerTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Event
+ * @package Cake\TwigView\Test\Event
  */
 class TokenParsersListenerTest extends TestCase
 {

--- a/tests/Lib/RelativeScannerTest.php
+++ b/tests/Lib/RelativeScannerTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib;
+namespace Cake\TwigView\Test\Lib;
 
 use Cake\Routing\Router;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Lib\RelativeScanner;
+use Cake\TwigView\Lib\RelativeScanner;
+use Cake\TwigView\Test\TestCase;
 
 /**
  * Class RelativeScannerTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig
+ * @package Cake\TwigView\Test\Lib\Twig
  */
 class RelativeScannerTest extends TestCase
 {

--- a/tests/Lib/ScannerTest.php
+++ b/tests/Lib/ScannerTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib;
+namespace Cake\TwigView\Test\Lib;
 
 use Cake\Routing\Router;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Lib\Scanner;
+use Cake\TwigView\Lib\Scanner;
+use Cake\TwigView\Test\TestCase;
 
 /**
  * Class ScannerTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig
+ * @package Cake\TwigView\Test\Lib\Twig
  */
 class ScannerTest extends TestCase
 {

--- a/tests/Lib/TreeScannerTest.php
+++ b/tests/Lib/TreeScannerTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib;
+namespace Cake\TwigView\Test\Lib;
 
 use Cake\Routing\Router;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Lib\TreeScanner;
+use Cake\TwigView\Lib\TreeScanner;
+use Cake\TwigView\Test\TestCase;
 
 /**
  * Class TreeScannerTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig
+ * @package Cake\TwigView\Test\Lib\Twig
  */
 class TreeScannerTest extends TestCase
 {

--- a/tests/Lib/Twig/Extension/AbstractExtensionTest.php
+++ b/tests/Lib/Twig/Extension/AbstractExtensionTest.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Test\Lib\Twig\Extension;
 
+use Cake\TwigView\Test\TestCase;
 use Twig\TokenParser\TokenParserInterface;
 use Twig\TwigFilter;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
 
 abstract class AbstractExtensionTest extends TestCase
 {

--- a/tests/Lib/Twig/Extension/BasicTest.php
+++ b/tests/Lib/Twig/Extension/BasicTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Test\Lib\Twig\Extension;
 
-use WyriHaximus\TwigView\Lib\Twig\Extension\Basic;
+use Cake\TwigView\Lib\Twig\Extension\Basic;
 
 final class BasicTest extends AbstractExtensionTest
 {

--- a/tests/Lib/Twig/Extension/PotentialDangerousTest.php
+++ b/tests/Lib/Twig/Extension/PotentialDangerousTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Test\Lib\Twig\Extension;
 
-use WyriHaximus\TwigView\Lib\Twig\Extension\PotentialDangerous;
+use Cake\TwigView\Lib\Twig\Extension\PotentialDangerous;
 
 final class PotentialDangerousTest extends AbstractExtensionTest
 {

--- a/tests/Lib/Twig/Extension/StringsTest.php
+++ b/tests/Lib/Twig/Extension/StringsTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig\Extension;
+namespace Cake\TwigView\Test\Lib\Twig\Extension;
 
-use WyriHaximus\TwigView\Lib\Twig\Extension\Strings;
+use Cake\TwigView\Lib\Twig\Extension\Strings;
 
 final class StringsTest extends AbstractExtensionTest
 {

--- a/tests/Lib/Twig/LoaderTest.php
+++ b/tests/Lib/Twig/LoaderTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig;
+namespace Cake\TwigView\Test\Lib\Twig;
 
+use Cake\TwigView\Lib\Twig\Loader;
+use Cake\TwigView\Test\TestCase;
 use Twig\Error\LoaderError;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Lib\Twig\Loader;
 
 /**
  * Class LoaderTest.
- * @package WyriHaximus\CakePHP\Tests\TwigView\Lib\Twig
+ * @package Cake\TwigView\Test\Lib\Twig
  */
 class LoaderTest extends TestCase
 {

--- a/tests/Panel/TwigPanelTest.php
+++ b/tests/Panel/TwigPanelTest.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Panel;
+namespace Cake\TwigView\Test\Panel;
 
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Lib\TreeScanner;
-use WyriHaximus\TwigView\Panel\TwigPanel;
+use Cake\TwigView\Lib\TreeScanner;
+use Cake\TwigView\Panel\TwigPanel;
+use Cake\TwigView\Test\TestCase;
 
 class TwigPanelTest extends TestCase
 {

--- a/tests/Shell/CompileShellTest.php
+++ b/tests/Shell/CompileShellTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Shell;
+namespace Cake\TwigView\Test\Shell;
 
 use Cake\Console\ConsoleOptionParser;
+use Cake\TwigView\Lib\Scanner;
+use Cake\TwigView\Shell\CompileShell;
+use Cake\TwigView\Test\TestCase;
+use Cake\TwigView\View\TwigView;
 use Twig\Environment;
 use Twig\Template;
 use Twig\TemplateWrapper;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Lib\Scanner;
-use WyriHaximus\TwigView\Shell\CompileShell;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class CompileShell.
- * @package WyriHaximus\TwigView\Shell
+ * @package Cake\TwigView\Shell
  */
 class CompileShellTest extends TestCase
 {

--- a/tests/Shell/Task/TemplateTask/AuthorsController.php
+++ b/tests/Shell/Task/TemplateTask/AuthorsController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Shell\Task\TemplateTask;
+namespace Cake\TwigView\Test\Shell\Task\TemplateTask;
 
 use Cake\Controller\Controller;
 

--- a/tests/Shell/Task/TemplateTask/AuthorsTable.php
+++ b/tests/Shell/Task/TemplateTask/AuthorsTable.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Shell\Task\TemplateTask;
+namespace Cake\TwigView\Test\Shell\Task\TemplateTask;
 
 use Cake\ORM\Table;
 

--- a/tests/Shell/Task/TwigTemplateTaskTest.php
+++ b/tests/Shell/Task/TwigTemplateTaskTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace WyriHaximus\CakePHP\Tests\TwigView\Shell\Task;
+namespace Cake\TwigView\Test\Shell\Task;
 
 use Bake\Shell\Task\BakeTemplateTask;
 use Bake\Shell\Task\ModelTask;
@@ -18,8 +18,8 @@ use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\StringCompareTrait;
-use WyriHaximus\CakePHP\Tests\TwigView\TestCase;
-use WyriHaximus\TwigView\Shell\Task\TwigTemplateTask;
+use Cake\TwigView\Shell\Task\TwigTemplateTask;
+use Cake\TwigView\Test\TestCase;
 
 /**
  * TwigTemplateTaskTest class.
@@ -48,7 +48,7 @@ class TwigTemplateTaskTest extends TestCase
         parent::setUp();
         $this->_compareBasePath = PLUGIN_REPO_ROOT . 'tests' . DS . 'comparisons' . DIRECTORY_SEPARATOR;
 
-        Configure::write('App.namespace', 'WyriHaximus\TwigView\Test\App');
+        Configure::write('App.namespace', 'Cake\TwigView\Test\App');
         $this->setupTask(['in', 'err', 'error', 'createFile', '_stop']);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\CakePHP\Tests\TwigView;
+namespace Cake\TwigView\Test;
 
 use Cake\TestSuite\TestCase as CakeTestCase;
 

--- a/tests/View/TwigViewTest.php
+++ b/tests/View/TwigViewTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace WyriHaximus\CakePHP\Tests\TwigView;
+namespace Cake\TwigView\Test;
 
 /**
  * This file is part of TwigView.
@@ -16,11 +16,11 @@ use App\Exception\MissingSomethingException;
 use App\View\AppView;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
+use Cake\TwigView\Event\ConstructEvent;
+use Cake\TwigView\Event\EnvironmentConfigEvent;
+use Cake\TwigView\View\TwigView;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
-use WyriHaximus\TwigView\Event\ConstructEvent;
-use WyriHaximus\TwigView\Event\EnvironmentConfigEvent;
-use WyriHaximus\TwigView\View\TwigView;
 
 /**
  * Class TwigViewTest.
@@ -116,11 +116,11 @@ class TwigViewTest extends TestCase
 
     /**
      * @param $name
-     * @return \WyriHaximus\CakePHP\Tests\TwigView\ReflectionMethod
+     * @return \Cake\TwigView\Test\ReflectionMethod
      */
     protected static function getMethod($name)
     {
-        $class = new ReflectionClass('WyriHaximus\TwigView\View\TwigView');
+        $class = new ReflectionClass('Cake\TwigView\View\TwigView');
         $method = $class->getMethod($name);
         $method->setAccessible(true);
 
@@ -129,11 +129,11 @@ class TwigViewTest extends TestCase
 
     /**
      * @param $name
-     * @return \WyriHaximus\CakePHP\Tests\TwigView\ReflectionProperty
+     * @return \Cake\TwigView\Test\ReflectionProperty
      */
     protected static function getProperty($name)
     {
-        $class = new ReflectionClass('WyriHaximus\TwigView\View\TwigView');
+        $class = new ReflectionClass('Cake\TwigView\View\TwigView');
         $property = $class->getProperty($name);
         $property->setAccessible(true);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,7 +33,7 @@ if (!getenv('db_dsn')) {
 }
 ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
 
-Plugin::getCollection()->add(new \WyriHaximus\TwigView\Plugin());
+Plugin::getCollection()->add(new \Cake\TwigView\Plugin());
 
 Configure::write(
     'App',

--- a/tests/test_app/View/AppView.php
+++ b/tests/test_app/View/AppView.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace App\View;
 
-class AppView extends \WyriHaximus\TwigView\View\TwigView
+class AppView extends \Cake\TwigView\View\TwigView
 {
     /**
      * Initialization hook method.


### PR DESCRIPTION
https://github.com/cakephp/twig-view/issues/253

This renames the php namespace along with the Configure and Plugin namespace.

The internal Twig extension/loader classes are not aliased.