### PR TITLE
5.1 - Add class aliases for shell

### DIFF
--- a/src/Shell/CompileShell.php
+++ b/src/Shell/CompileShell.php
@@ -155,3 +155,7 @@ class CompileShell extends Shell
         }
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Shell\CompileShell', 'Wyrihaximus\TwigView\Shell\CompileShell');
+// phpcs:enable

--- a/src/Shell/Task/TwigTemplateTask.php
+++ b/src/Shell/Task/TwigTemplateTask.php
@@ -56,3 +56,7 @@ final class TwigTemplateTask extends TemplateTask
         return $content;
     }
 }
+
+// phpcs:disable
+class_alias('Cake\TwigView\Shell\Task\TwigTemplateTask', 'Wyrihaximus\TwigView\Shell\Task\TwigTemplateTask');
+// phpcs:enable


### PR DESCRIPTION
We need aliases for these internal classes to allow cakephp's directory scanning to work.