### PR TITLE
Add test showing usage of "do" tag.

### DIFF
--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -74,16 +74,6 @@ class TwigView extends View
     protected $profile;
 
     /**
-     * Return empty string when View instance is cast to string.
-     *
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return '';
-    }
-
-    /**
      * Initialize view.
      *
      * @return void

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -64,7 +64,20 @@ class TwigViewTest extends TestCase
         $view = new AppView();
         $output = $view->render('Blog/index');
 
-        $this->assertSame('blog_entry', $output);
+        $this->assertSame("blog_entry", $output);
+    }
+
+    /**
+     * Test rendering template with view block assignment
+     *
+     * @return void
+     */
+    public function testRenderLayoutWithViewBlockAssignment()
+    {
+        $view = new AppView();
+        $output = $view->render('Blog/with_extra_block', 'with_extra_block');
+
+        $this->assertSame("main content\nextra content", $output);
     }
 
     /**

--- a/tests/test_app/templates/Blog/with_extra_block.twig
+++ b/tests/test_app/templates/Blog/with_extra_block.twig
@@ -1,0 +1,2 @@
+main content
+{% do _view.assign('block', 'extra content') %}

--- a/tests/test_app/templates/layout/with_extra_block.twig
+++ b/tests/test_app/templates/layout/with_extra_block.twig
@@ -1,0 +1,5 @@
+{{ _view.fetch('content')|raw }}
+
+{%- if _view.exists('block') %}
+{{ _view.fetch('block')|raw }}
+{%- endif -%}


### PR DESCRIPTION
Using "do" allows calling functions without printing any output hence TwigView::__toString() is not needed.
Also closes #4.