### PR TITLE
Added configuration for View instance variable name in templates

### DIFF
--- a/src/Twig/Node/Cell.php
+++ b/src/Twig/Node/Cell.php
@@ -95,7 +95,7 @@ class Cell extends Node implements NodeOutputInterface
         } else {
             $compiler->raw('echo ');
         }
-        $compiler->raw('$context[\'_view\']->cell(');
+        $compiler->raw('$context[\'this\']->cell(');
         $compiler->subcompile($this->getNode('name'));
 
         $data = $this->getNode('data');

--- a/src/Twig/Node/Element.php
+++ b/src/Twig/Node/Element.php
@@ -74,7 +74,7 @@ class Element extends Node
     {
         $compiler->addDebugInfo($this);
 
-        $compiler->raw('echo $context[\'_view\']->element(');
+        $compiler->raw('echo $context[\'this\']->element(');
         $compiler->subcompile($this->getNode('name'));
 
         $data = $this->getNode('data');

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -57,6 +57,7 @@ class TwigView extends View
      * - `markdown` - Config for MarkdownExtension. Array must contain `engine` key which is
      *   an instance of Twig\Extra\Markdown\MarkdownInterface,
      *   see https://twig.symfony.com/doc/3.x/filters/markdown_to_html.html
+     * - 'viewVar' - Twig template variable name to access View. Defaults to `this`.
      *
      * @var array
      */
@@ -66,6 +67,7 @@ class TwigView extends View
         'markdown' => [
             'engine' => null,
         ],
+        'viewVar' => 'this',
     ];
 
     /**
@@ -256,11 +258,12 @@ class TwigView extends View
      */
     protected function _render(string $templateFile, array $data = []): string
     {
+        $viewVar = $this->getConfig('viewVar');
         $data = array_merge(
             empty($data) ? $this->viewVars : $data,
             iterator_to_array($this->helpers()->getIterator()),
             [
-                '_view' => $this,
+                $viewVar => $this,
             ]
         );
 

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -64,7 +64,7 @@ class TwigViewTest extends TestCase
         $view = new AppView();
         $output = $view->render('Blog/index');
 
-        $this->assertSame("blog_entry", $output);
+        $this->assertSame('blog_entry', $output);
     }
 
     /**
@@ -78,6 +78,16 @@ class TwigViewTest extends TestCase
         $output = $view->render('Blog/with_extra_block', 'with_extra_block');
 
         $this->assertSame("main content\nextra content", $output);
+    }
+
+    public function testCustomViewVariable()
+    {
+        $view = new AppView(null, null, null, ['viewVar' => 'myView']);
+
+        $view->assign('title', 'my title');
+        $output = $view->render('custom_variable', false);
+
+        $this->assertSame('my title', $output);
     }
 
     /**

--- a/tests/test_app/templates/Blog/with_extra_block.twig
+++ b/tests/test_app/templates/Blog/with_extra_block.twig
@@ -1,2 +1,2 @@
 main content
-{% do _view.assign('block', 'extra content') %}
+{% do this.assign('block', 'extra content') %}

--- a/tests/test_app/templates/custom_variable.twig
+++ b/tests/test_app/templates/custom_variable.twig
@@ -1,0 +1,1 @@
+{{ myView.fetch('title')|raw }}

--- a/tests/test_app/templates/layout/default.twig
+++ b/tests/test_app/templates/layout/default.twig
@@ -1,1 +1,1 @@
-{{ _view.fetch('content')|raw }}
+{{ this.fetch('content')|raw }}

--- a/tests/test_app/templates/layout/with_extra_block.twig
+++ b/tests/test_app/templates/layout/with_extra_block.twig
@@ -1,5 +1,5 @@
-{{ _view.fetch('content')|raw }}
+{{ this.fetch('content')|raw }}
 
-{%- if _view.exists('block') %}
-{{ _view.fetch('block')|raw }}
+{%- if this.exists('block') %}
+{{ this.fetch('block')|raw }}
 {%- endif -%}


### PR DESCRIPTION
This let's you override the default `_view` template variable name.