### PR TITLE
Use Twig function to call CakePHP helpers.

### DIFF
--- a/src/Twig/Extension/ViewExtension.php
+++ b/src/Twig/Extension/ViewExtension.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\TwigView\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Class ViewExtension.
+ */
+class ViewExtension extends AbstractExtension
+{
+    /**
+     * Get declared functions.
+     *
+     * @return \Twig\TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'helper_*_*',
+                function ($context, $helper, $method, array $args = []) {
+                    return $context['_view']->{$helper}->{$method}(...$args);
+                },
+                ['needs_context' => true, 'is_variadic' => true, 'is_safe' => ['all']]
+            ),
+        ];
+    }
+
+    /**
+     * Get extension name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'twigview-view';
+    }
+}

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -200,6 +200,7 @@ class TwigView extends View
         $this->twig->addExtension(new Extension\StringsExtension());
         $this->twig->addExtension(new Extension\TimeExtension());
         $this->twig->addExtension(new Extension\UtilsExtension());
+        $this->twig->addExtension(new Extension\ViewExtension());
 
         // Markdown extension
         $markdownEngine = $this->getConfig('markdown.engine');

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -112,4 +112,16 @@ class TwigViewTest extends TestCase
 
         $this->view->render('syntaxerror', false);
     }
+
+    public function testHelperFunction()
+    {
+        $view = new AppView(null, null, null, [
+            'viewVars' => ['elementVar' => 'var echoed inside element'],
+        ]);
+
+        $output = $view->render('helper_test', false);
+
+        $expected = "var echoed inside element\n<p>I love CakePHP</p>\n";
+        $this->assertSame($expected, $output);
+    }
 }

--- a/tests/test_app/src/View/Helper/TestSecondHelper.php
+++ b/tests/test_app/src/View/Helper/TestSecondHelper.php
@@ -27,4 +27,9 @@ class TestSecondHelper extends Helper
     {
         throw new MissingSomethingException('Something is missing');
     }
+
+    public function useElement()
+    {
+        return $this->_View->element('element_with_var');
+    }
 }

--- a/tests/test_app/templates/element/element_with_var.twig
+++ b/tests/test_app/templates/element/element_with_var.twig
@@ -1,0 +1,1 @@
+{{ elementVar }}

--- a/tests/test_app/templates/helper_test.twig
+++ b/tests/test_app/templates/helper_test.twig
@@ -1,0 +1,2 @@
+{{ helper_TestSecond_useElement() }}
+{{ helper_Text_autoParagraph('I love CakePHP') }}


### PR DESCRIPTION
This avoids having to preload helpers as with current usage and
also avoids having to add |raw at the end of calls to prevent escaping.