### PR TITLE
View instance variable

### DIFF
--- a/src/Twig/Node/Cell.php
+++ b/src/Twig/Node/Cell.php
@@ -95,7 +95,7 @@ class Cell extends Node implements NodeOutputInterface
         } else {
             $compiler->raw('echo ');
         }
-        $compiler->raw('$context[\'this\']->cell(');
+        $compiler->raw('$context[\'_view\']->cell(');
         $compiler->subcompile($this->getNode('name'));
 
         $data = $this->getNode('data');

--- a/src/Twig/Node/Element.php
+++ b/src/Twig/Node/Element.php
@@ -74,7 +74,7 @@ class Element extends Node
     {
         $compiler->addDebugInfo($this);
 
-        $compiler->raw('echo $context[\'this\']->element(');
+        $compiler->raw('echo $context[\'_view\']->element(');
         $compiler->subcompile($this->getNode('name'));
 
         $data = $this->getNode('data');

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -57,7 +57,6 @@ class TwigView extends View
      * - `markdown` - Config for MarkdownExtension. Array must contain `engine` key which is
      *   an instance of Twig\Extra\Markdown\MarkdownInterface,
      *   see https://twig.symfony.com/doc/3.x/filters/markdown_to_html.html
-     * - 'viewVar' - Twig template variable name to access View. Defaults to `this`.
      *
      * @var array
      */
@@ -67,7 +66,6 @@ class TwigView extends View
         'markdown' => [
             'engine' => null,
         ],
-        'viewVar' => 'this',
     ];
 
     /**
@@ -258,12 +256,11 @@ class TwigView extends View
      */
     protected function _render(string $templateFile, array $data = []): string
     {
-        $viewVar = $this->getConfig('viewVar');
         $data = array_merge(
             empty($data) ? $this->viewVars : $data,
             iterator_to_array($this->helpers()->getIterator()),
             [
-                $viewVar => $this,
+                '_view' => $this,
             ]
         );
 

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -101,7 +101,8 @@ class TwigView extends View
     {
         parent::initialize();
 
-        $this->twig = new Environment($this->createLoader(), $this->createEnvironmentConfig());
+        $this->twig = $this->createEnvironment();
+
         $this->initializeTokenParser();
         $this->initializeExtensions();
 
@@ -141,11 +142,11 @@ class TwigView extends View
     }
 
     /**
-     * Creates the Twig Environment configuration.
+     * Creates the Twig Environment.
      *
-     * @return array
+     * @return \Twig\Environment
      */
-    protected function createEnvironmentConfig(): array
+    protected function createEnvironment(): Environment
     {
         $debug = Configure::read('debug', false);
 
@@ -159,7 +160,10 @@ class TwigView extends View
             $config['cache'] = CACHE . 'twigView' . DS;
         }
 
-        return $config;
+        $env = new Environment($this->createLoader(), $config);
+        $env->addGlobal('_view', $this);
+
+        return $env;
     }
 
     /**
@@ -258,10 +262,7 @@ class TwigView extends View
     {
         $data = array_merge(
             empty($data) ? $this->viewVars : $data,
-            iterator_to_array($this->helpers()->getIterator()),
-            [
-                '_view' => $this,
-            ]
+            iterator_to_array($this->helpers()->getIterator())
         );
 
         return $this->getTwig()->load($templateFile)->render($data);

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -73,7 +73,7 @@ class TwigViewTest extends TestCase
     {
         $output = $this->view->render('Blog/index');
 
-        $this->assertSame('blog_entry', $output);
+        $this->assertSame("blog_entry", $output);
     }
 
     /**
@@ -86,16 +86,6 @@ class TwigViewTest extends TestCase
         $output = $this->view->render('Blog/with_extra_block', 'with_extra_block');
 
         $this->assertSame("main content\nextra content", $output);
-    }
-
-    public function testCustomViewVariable()
-    {
-        $view = new AppView(null, null, null, ['viewVar' => 'myView']);
-
-        $view->assign('title', 'my title');
-        $output = $view->render('custom_variable', false);
-
-        $this->assertSame('my title', $output);
     }
 
     /**

--- a/tests/test_app/templates/Blog/with_extra_block.twig
+++ b/tests/test_app/templates/Blog/with_extra_block.twig
@@ -1,2 +1,2 @@
 main content
-{% do this.assign('block', 'extra content') %}
+{% do _view.assign('block', 'extra content') %}

--- a/tests/test_app/templates/custom_variable.twig
+++ b/tests/test_app/templates/custom_variable.twig
@@ -1,1 +1,0 @@
-{{ myView.fetch('title')|raw }}

--- a/tests/test_app/templates/layout/default.twig
+++ b/tests/test_app/templates/layout/default.twig
@@ -1,1 +1,1 @@
-{{ this.fetch('content')|raw }}
+{{ _view.fetch('content')|raw }}

--- a/tests/test_app/templates/layout/with_extra_block.twig
+++ b/tests/test_app/templates/layout/with_extra_block.twig
@@ -1,5 +1,5 @@
-{{ this.fetch('content')|raw }}
+{{ _view.fetch('content')|raw }}
 
-{%- if this.exists('block') %}
-{{ this.fetch('block')|raw }}
+{%- if _view.exists('block') %}
+{{ _view.fetch('block')|raw }}
 {%- endif -%}


### PR DESCRIPTION
- Reverts changes done in #21. The ability to change view instance variable name isn't really necessary and causes unnecessary complications.
- Add View instance as a [global variable](https://twig.symfony.com/doc/3.x/advanced.html#globals)
- Move twig env. instance creation into separate method.