### PR TITLE
Changed file scanners to accept list of extensions

### DIFF
--- a/src/Filesystem/RelativeScanner.php
+++ b/src/Filesystem/RelativeScanner.php
@@ -31,23 +31,25 @@ final class RelativeScanner
     /**
      * Return all sections (app & plugins) with an Template directory.
      *
+     * @param string[] $extensions Template extensions to search
      * @return array
      */
-    public static function all(): array
+    public static function all(array $extensions): array
     {
-        return static::strip(Scanner::all());
+        return static::strip(Scanner::all($extensions));
     }
 
     /**
      * Return all templates for a given plugin.
      *
      * @param string $plugin The plugin to find all templates for.
+     * @param string[] $extensions Template extensions to search
      * @return mixed
      */
-    public static function plugin(string $plugin)
+    public static function plugin(string $plugin, array $extensions)
     {
         return static::strip([
-            $plugin => Scanner::plugin($plugin),
+            $plugin => Scanner::plugin($plugin, $extensions),
         ])[$plugin];
     }
 

--- a/src/Filesystem/TreeScanner.php
+++ b/src/Filesystem/TreeScanner.php
@@ -28,23 +28,25 @@ final class TreeScanner
     /**
      * Return all sections (app & plugins) with an Template directory.
      *
+     * @param string[] $extensions Template extensions to search
      * @return array
      */
-    public static function all(): array
+    public static function all(array $extensions): array
     {
-        return static::deepen(RelativeScanner::all());
+        return static::deepen(RelativeScanner::all($extensions));
     }
 
     /**
      * Return all templates for a given plugin.
      *
      * @param string $plugin The plugin to find all templates for.
+     * @param string[] $extensions Template extensions to search
      * @return array
      */
-    public static function plugin(string $plugin): array
+    public static function plugin(string $plugin, array $extensions): array
     {
         return static::deepen([
-            $plugin => RelativeScanner::plugin($plugin),
+            $plugin => RelativeScanner::plugin($plugin, $extensions),
         ])[$plugin];
     }
 

--- a/src/Panel/TwigPanel.php
+++ b/src/Panel/TwigPanel.php
@@ -24,6 +24,11 @@ use DebugKit\DebugPanel;
 class TwigPanel extends DebugPanel
 {
     /**
+     * @var string[]
+     */
+    protected static $extensions = [];
+
+    /**
      * Plugin name.
      *
      * @var string
@@ -38,7 +43,18 @@ class TwigPanel extends DebugPanel
     public function data(): array
     {
         return [
-            'templates' => TreeScanner::all(),
+            'templates' => TreeScanner::all(static::$extensions),
         ];
+    }
+
+    /**
+     * Sets the template file extensions to search.
+     *
+     * @param string[] $extensions Template extensions to search
+     * @return void
+     */
+    public static function setExtensions(array $extensions): void
+    {
+        static::$extensions = $extensions;
     }
 }

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -20,6 +20,7 @@ namespace Cake\TwigView\View;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\TwigView\Panel\TwigPanel;
 use Cake\TwigView\Twig\Extension;
 use Cake\TwigView\Twig\Loader;
 use Cake\TwigView\Twig\TokenParser;
@@ -45,8 +46,6 @@ use Twig\RuntimeLoader\RuntimeLoaderInterface;
  */
 class TwigView extends View
 {
-    public const EXT = '.twig';
-
     /**
      * Default config options.
      *
@@ -109,6 +108,8 @@ class TwigView extends View
         if (Configure::read('debug') && Plugin::isLoaded('DebugKit')) {
             $this->initializeProfiler();
         }
+
+        TwigPanel::setExtensions($this->extensions);
     }
 
     /**
@@ -129,6 +130,15 @@ class TwigView extends View
     public function getProfile(): Profile
     {
         return $this->profile;
+    }
+
+    /** Gets the template file extensions.
+     *
+     * @return string[]
+     */
+    public function getExtensions(): array
+    {
+        return $this->extensions;
     }
 
     /**

--- a/tests/TestCase/Command/CompileCommandTest.php
+++ b/tests/TestCase/Command/CompileCommandTest.php
@@ -111,4 +111,18 @@ class CompileCommandTest extends TestCase
 
         Configure::write('App.paths.templates', $templates);
     }
+
+    /**
+     * Test passing view class option.
+     *
+     * @return void
+     */
+    public function testViewOption()
+    {
+        $path = TEST_APP . DS . 'templates' . DS . 'simple.twig';
+        $this->exec('twig-view compile file --view-class TestApp\View\AppView ' . $path);
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Compiled');
+        $this->assertOutputContains(TEST_APP . DS . 'templates' . DS . 'simple.twig');
+    }
 }

--- a/tests/TestCase/Filesystem/RelativeScannerTest.php
+++ b/tests/TestCase/Filesystem/RelativeScannerTest.php
@@ -79,11 +79,12 @@ class RelativeScannerTest extends TestCase
                 'Controller/Component/magic.twig',
                 'Controller/index.twig',
                 'Controller/view.twig',
+                'element/nested/plugin_test.twig',
                 'twig.twig',
             ],
         ];
 
-        $this->assertEquals($expected, RelativeScanner::all());
+        $this->assertEquals($expected, RelativeScanner::all(['.twig']));
 
         Configure::write('App.paths.templates', $templatePaths);
     }
@@ -94,7 +95,8 @@ class RelativeScannerTest extends TestCase
             'Controller/Component/magic.twig',
             'Controller/index.twig',
             'Controller/view.twig',
+            'element/nested/plugin_test.twig',
             'twig.twig',
-        ], RelativeScanner::plugin('TestTwigView'));
+        ], RelativeScanner::plugin('TestTwigView', ['.twig']));
     }
 }

--- a/tests/TestCase/Filesystem/ScannerTest.php
+++ b/tests/TestCase/Filesystem/ScannerTest.php
@@ -78,9 +78,11 @@ class ScannerTest extends TestCase
                 TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'Controller' . DS . 'Component' . DS . 'magic.twig',
                 TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'Controller' . DS . 'index.twig',
                 TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'Controller' . DS . 'view.twig',
+                TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'element' . DS . 'nested' . DS . 'plugin_test.twig',
+                TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'other.other',
                 TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'twig.twig',
             ],
-        ], Scanner::all());
+        ], Scanner::all(['.twig', '.other']));
 
         Configure::write('App.paths.templates', $templatePaths);
     }
@@ -91,7 +93,8 @@ class ScannerTest extends TestCase
             TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'Controller' . DS . 'Component' . DS . 'magic.twig',
             TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'Controller' . DS . 'index.twig',
             TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'Controller' . DS . 'view.twig',
+            TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'element' . DS . 'nested' . DS . 'plugin_test.twig',
             TEST_APP . 'plugins' . DS . 'TestTwigView' . DS . 'templates' . DS . 'twig.twig',
-        ], Scanner::plugin('TestTwigView'));
+        ], Scanner::plugin('TestTwigView', ['.twig']));
     }
 }

--- a/tests/TestCase/Filesystem/TreeScannerTest.php
+++ b/tests/TestCase/Filesystem/TreeScannerTest.php
@@ -81,7 +81,7 @@ class TreeScannerTest extends TestCase
                 ],
             ],
             'TestTwigView' => [
-                3 => 'twig.twig',
+                4 => 'twig.twig',
                 'Controller' => [
                     'Component' => [
                         'magic.twig',
@@ -89,8 +89,13 @@ class TreeScannerTest extends TestCase
                     'index.twig',
                     'view.twig',
                 ],
+                'element' => [
+                    'nested' => [
+                        'plugin_test.twig',
+                    ],
+                ],
             ],
-        ], TreeScanner::all());
+        ], TreeScanner::all(['.twig']));
 
         Configure::write('App.paths.templates', $templatePaths);
     }
@@ -98,7 +103,7 @@ class TreeScannerTest extends TestCase
     public function testPlugin()
     {
         $this->assertSame([
-            3 => 'twig.twig',
+            4 => 'twig.twig',
             'Controller' => [
                 'Component' => [
                     'magic.twig',
@@ -106,6 +111,11 @@ class TreeScannerTest extends TestCase
                 'index.twig',
                 'view.twig',
             ],
-        ], TreeScanner::plugin('TestTwigView'));
+            'element' => [
+                'nested' => [
+                    'plugin_test.twig',
+                ],
+            ],
+        ], TreeScanner::plugin('TestTwigView', ['.twig']));
     }
 }

--- a/tests/TestCase/Panel/TwigPanelTest.php
+++ b/tests/TestCase/Panel/TwigPanelTest.php
@@ -26,8 +26,11 @@ class TwigPanelTest extends TestCase
 {
     public function testData()
     {
+        $panel = new TwigPanel();
+        $panel->setExtensions(['.twig']);
+
         $this->assertSame([
-            'templates' => TreeScanner::all(),
-        ], (new TwigPanel())->data());
+            'templates' => TreeScanner::all(['.twig']),
+        ], $panel->data());
     }
 }

--- a/tests/TestCase/Twig/LoaderTest.php
+++ b/tests/TestCase/Twig/LoaderTest.php
@@ -52,8 +52,8 @@ class LoaderTest extends TestCase
 
     public function testGetSource()
     {
-        $this->assertSame('TwigView', $this->Loader->getSource('TestTwigView.twig'));
-        $this->assertSame('TwigView', $this->Loader->getSource('TestTwigView.twig.twig'));
+        $source = $this->Loader->getSource(TEST_APP . DS . 'templates' . DS . 'simple.twig');
+        $this->assertSame("{{ 'UnderscoreMe'|underscore }}", $source);
     }
 
     public function testGetSourceNonExistingFile()
@@ -63,23 +63,11 @@ class LoaderTest extends TestCase
         $this->Loader->getSource('TestTwigView.no_twig');
     }
 
-    public function testGetCacheKeyNoPlugin()
+    public function testGetCacheKey()
     {
         $this->assertSame(
             TEST_APP . 'templates/simple.twig',
-            $this->Loader->getCacheKey('simple')
-        );
-    }
-
-    public function testGetCacheKeyPlugin()
-    {
-        $this->assertSame(
-            TEST_APP . 'plugins/TestTwigView/templates/twig.twig',
-            $this->Loader->getCacheKey('TestTwigView.twig')
-        );
-        $this->assertSame(
-            TEST_APP . 'plugins/TestTwigView/templates/twig.twig',
-            $this->Loader->getCacheKey('TestTwigView.twig.twig')
+            $this->Loader->getCacheKey(TEST_APP . 'templates/simple.twig')
         );
     }
 

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -88,6 +88,16 @@ class TwigViewTest extends TestCase
         $this->assertSame("main content\nextra content", $output);
     }
 
+    public function testRenderWithPluginElement()
+    {
+        $this->loadPlugins(['TestTwigView']);
+
+        $output = $this->view->render('plugin', false);
+        $this->assertSame('from plugin', $output);
+
+        $this->removePlugins(['TestTwigView']);
+    }
+
     /**
      * Tests a twig file that throws internal exception throw a Twig exception with message.
      *

--- a/tests/test_app/plugins/TestTwigView/templates/element/nested/plugin_test.twig
+++ b/tests/test_app/plugins/TestTwigView/templates/element/nested/plugin_test.twig
@@ -1,0 +1,1 @@
+from plugin

--- a/tests/test_app/templates/plugin.twig
+++ b/tests/test_app/templates/plugin.twig
@@ -1,0 +1,1 @@
+{% element 'TestTwigView.nested/plugin_test' %}


### PR DESCRIPTION
https://github.com/cakephp/twig-view/issues/5

This removes the use of hard-coded `TwigView::EXT` constant. 

Simplified `Loader` which only needs to accept full template path.