### PR TITLE
Rename default cache folder.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,5 +17,5 @@ parameters:
 
         -
             message: "#^Constant CACHE not found\\.$#"
-            count: 2
+            count: 1
             path: src/View/TwigView.php

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -149,15 +149,16 @@ class TwigView extends View
     protected function createEnvironment(): Environment
     {
         $debug = Configure::read('debug', false);
+        $cachePath = CACHE . 'twig_view' . DS;
 
         $config = $this->getConfig('environment') + [
             'charset' => Configure::read('App.encoding', 'UTF-8'),
             'debug' => $debug,
-            'cache' => $debug ? false : CACHE . 'twigView' . DS,
+            'cache' => $debug ? false : $cachePath,
         ];
 
         if ($config['cache'] === true) {
-            $config['cache'] = CACHE . 'twigView' . DS;
+            $config['cache'] = $cachePath;
         }
 
         $env = new Environment($this->createLoader(), $config);


### PR DESCRIPTION
We generally use underscored file/folder names unless they need to
correspond to a class or method name.