### PR TITLE
Fix merge error

### DIFF
--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -151,7 +151,7 @@ class TwigView extends View
         $debug = Configure::read('debug', false);
         $cachePath = CACHE . 'twig_view' . DS;
 
-        $config = $this->getConfig('environment') + [
+        $config = (array)$this->getConfig('environment') + [
             'charset' => Configure::read('App.encoding', 'UTF-8'),
             'debug' => $debug,
             'cache' => $debug ? false : $cachePath,


### PR DESCRIPTION
https://github.com/cakephp/twig-view/commit/b04a18a195cf31aa8f9e7e83c1fc04d8a6ac685e#diff-75a2b2d5bfb0a0d9801eb03445a391edR152 removed the defaulting to an array

Which can cause e.g. https://travis-ci.org/github/dereuromark/cakephp-sandbox/jobs/670981642#L378

which is a bit weird, as the config should be an array here.

AHA

	/**
	 * This config is read when evaluating a template file.
	 *
	 * @var array
	 */
	protected $_defaultConfig = [
	];

inside the extending class kills it.

So I guess this is fine then and the extending class needs to merge differently in constructor.