### PR TITLE
Removed unused getName() from extensions

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,7 @@ parameters:
 
         -
             message: "#^Constant ROOT not found\\.$#"
-            count: 2
+            count: 1
             path: src/Twig/Extension/ProfilerExtension.php
 
         -

--- a/src/Twig/Extension/ArraysExtension.php
+++ b/src/Twig/Extension/ArraysExtension.php
@@ -45,14 +45,4 @@ class ArraysExtension extends AbstractExtension
             new TwigFunction('array_current', 'current'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-array';
-    }
 }

--- a/src/Twig/Extension/BasicExtension.php
+++ b/src/Twig/Extension/BasicExtension.php
@@ -46,14 +46,4 @@ class BasicExtension extends AbstractExtension
             }),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-basic';
-    }
 }

--- a/src/Twig/Extension/ConfigureExtension.php
+++ b/src/Twig/Extension/ConfigureExtension.php
@@ -39,14 +39,4 @@ class ConfigureExtension extends AbstractExtension
             new TwigFunction('config', 'Cake\Core\Configure::read'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'twigview-configure';
-    }
 }

--- a/src/Twig/Extension/I18nExtension.php
+++ b/src/Twig/Extension/I18nExtension.php
@@ -41,14 +41,4 @@ class I18nExtension extends AbstractExtension
             new TwigFunction('__dn', '__dn'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-i18n';
-    }
 }

--- a/src/Twig/Extension/InflectorExtension.php
+++ b/src/Twig/Extension/InflectorExtension.php
@@ -46,14 +46,4 @@ class InflectorExtension extends AbstractExtension
             new TwigFilter('slug', 'Cake\Utility\Text::slug'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-inflector';
-    }
 }

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -56,14 +56,4 @@ class NumberExtension extends AbstractExtension
             new TwigFunction('number_formatter', 'Cake\I18n\Number::formatter'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-number';
-    }
 }

--- a/src/Twig/Extension/ProfilerExtension.php
+++ b/src/Twig/Extension/ProfilerExtension.php
@@ -40,18 +40,4 @@ class ProfilerExtension extends TwigProfilerExtension
 
         parent::enter($profile);
     }
-
-    /**
-     * Leave $profile.
-     *
-     * @param \Twig\Profiler\Profile $profile Profile.
-     * @return void
-     */
-    public function leave(Profile $profile)
-    {
-        parent::leave($profile);
-
-        $name = 'Twig Template: ' . substr($profile->getName(), strlen(ROOT) + 1);
-        DebugTimer::stop($name);
-    }
 }

--- a/src/Twig/Extension/StringsExtension.php
+++ b/src/Twig/Extension/StringsExtension.php
@@ -69,14 +69,4 @@ class StringsExtension extends AbstractExtension
             new TwigFunction('sprintf', 'sprintf'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-string';
-    }
 }

--- a/src/Twig/Extension/TimeExtension.php
+++ b/src/Twig/Extension/TimeExtension.php
@@ -41,14 +41,4 @@ class TimeExtension extends AbstractExtension
             new TwigFunction('timezones', 'Cake\I18n\Time::listTimezones'),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-time';
-    }
 }

--- a/src/Twig/Extension/UtilsExtension.php
+++ b/src/Twig/Extension/UtilsExtension.php
@@ -44,14 +44,4 @@ class UtilsExtension extends AbstractExtension
             }),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-utils';
-    }
 }

--- a/src/Twig/Extension/ViewExtension.php
+++ b/src/Twig/Extension/ViewExtension.php
@@ -56,14 +56,4 @@ class ViewExtension extends AbstractExtension
             ),
         ];
     }
-
-    /**
-     * Get extension name.
-     *
-     * @return string
-     */
-    public function getName(): string
-    {
-        return 'twigview-view';
-    }
 }

--- a/tests/TestCase/Twig/Extension/AbstractExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/AbstractExtensionTest.php
@@ -66,13 +66,6 @@ abstract class AbstractExtensionTest extends TestCase
         }
     }
 
-    public function testName()
-    {
-        $name = $this->extension->getName();
-        $this->assertIsString($name);
-        $this->assertTrue(strlen($name) > 0);
-    }
-
     protected function getFilter($name)
     {
         $filters = $this->extension->getFilters();


### PR DESCRIPTION
`getName()` isn't part of any interface and isn't used. Will just confuse people.