### PR TITLE
Added deprecation warning for cell and element tags

### DIFF
--- a/src/Twig/TokenParser/CellParser.php
+++ b/src/Twig/TokenParser/CellParser.php
@@ -38,6 +38,12 @@ class CellParser extends IncludeTokenParser
      */
     public function parse(Token $token): Node
     {
+        static $warned = false;
+        if (!$warned) {
+            $warned = true;
+            deprecationWarning('`cell` tag is deprecated. Use `cell()` function instead.');
+        }
+
         $stream = $this->parser->getStream();
 
         $variable = null;

--- a/src/Twig/TokenParser/ElementParser.php
+++ b/src/Twig/TokenParser/ElementParser.php
@@ -38,6 +38,12 @@ class ElementParser extends IncludeTokenParser
      */
     public function parse(Token $token): Node
     {
+        static $warned = false;
+        if (!$warned) {
+            $warned = true;
+            deprecationWarning('`element` tag is deprecated. Use `element()` function instead.');
+        }
+
         $stream = $this->parser->getStream();
         $name = $this->parser->getExpressionParser()->parseExpression();
 

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -127,8 +127,10 @@ class TwigViewTest extends TestCase
      */
     public function testDeprecatedTags()
     {
-        $output = $this->view->render('deprecated_tags', false);
-        $this->assertSame("<b>10</b>\nblog_entry", $output);
+        $this->deprecated(function () {
+            $output = $this->view->render('deprecated_tags', false);
+            $this->assertSame("<b>10</b>\nblog_entry", $output);
+        });
     }
 
     /**


### PR DESCRIPTION
I tried to limit it to one warning per render so we don't spam users.