### PR TITLE
Added FilesystemLoader to allow .twig to include and extend files

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,16 @@ You can override several parts of `TwigView` initialization to create a custom T
 ## Templates
 
 You can create views using Twig templates much like you can with standard CakePHP templates.
-Layouts, elements and cells should work the same as standard templates.
+
+When using `element()` and `cell()`, the templates are searched and loaded the same as View.
+You do not need to specify the full path or file extension.
+
+When using twig files directly (such as `include()`), TwigView will search the paths in
+`App.paths.templates` for the files. You must include the extension when loading files directly - `my_template.twig`.
 
 Since Twig provides a completely different `block` system, we recommend that you use Twig blocks and inheritance
-instead of trying to render CakePHP View blocks.
-
-However, you can still use standard blocks like `title`, `css`, `script` and `content`,  in your layouts.
+instead of trying to render CakePHP View blocks. However, you can still use standard blocks like
+`title`, `css`, `script` and `content`  in your layouts with the `fetch()` function.
 
 `templates/layout/default.twig`:
 

--- a/src/Twig/AbsolutePathLoader.php
+++ b/src/Twig/AbsolutePathLoader.php
@@ -23,11 +23,9 @@ use Twig\Loader\LoaderInterface;
 use Twig\Source;
 
 /**
- * Class Loader.
- *
- * @internal
+ * Loads template files with aboslute paths.
  */
-class Loader implements LoaderInterface
+class AbsolutePathLoader implements LoaderInterface
 {
     /**
      * Get the file contents of a template.

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -21,8 +21,8 @@ namespace Cake\TwigView\View;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TwigView\Panel\TwigPanel;
+use Cake\TwigView\Twig\AbsolutePathLoader;
 use Cake\TwigView\Twig\Extension;
-use Cake\TwigView\Twig\Loader;
 use Cake\TwigView\Twig\TokenParser;
 use Cake\View\Exception\MissingLayoutException;
 use Cake\View\Exception\MissingTemplateException;
@@ -39,6 +39,8 @@ use Twig\Extra\Markdown\DefaultMarkdown;
 use Twig\Extra\Markdown\MarkdownExtension;
 use Twig\Extra\Markdown\MarkdownInterface;
 use Twig\Extra\Markdown\MarkdownRuntime;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface;
 use Twig\Profiler\Profile;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
@@ -157,7 +159,10 @@ class TwigView extends View
      */
     protected function createLoader(): LoaderInterface
     {
-        return new Loader();
+        return new ChainLoader([
+            new AbsolutePathLoader(),
+            new FilesystemLoader(Configure::read('App.paths.templates')),
+        ]);
     }
 
     /**

--- a/tests/TestCase/Twig/AbsolutePathLoaderTest.php
+++ b/tests/TestCase/Twig/AbsolutePathLoaderTest.php
@@ -19,16 +19,16 @@ declare(strict_types=1);
 namespace Cake\TwigView\Test\TestCase\Twig;
 
 use Cake\TestSuite\TestCase;
-use Cake\TwigView\Twig\Loader;
+use Cake\TwigView\Twig\AbsolutePathLoader;
 use Twig\Error\LoaderError;
 
 /**
- * Class LoaderTest.
+ * Class AbsolutePathLoaderTest.
  */
-class LoaderTest extends TestCase
+class AbsolutePathLoaderTest extends TestCase
 {
     /**
-     * @var Loader
+     * @var Cake\TwigView\Twig\AbsolutePathLoader
      */
     protected $Loader;
 
@@ -38,7 +38,7 @@ class LoaderTest extends TestCase
 
         $this->loadPlugins(['TestTwigView']);
 
-        $this->Loader = new Loader();
+        $this->Loader = new AbsolutePathLoader();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -154,6 +154,18 @@ class TwigViewTest extends TestCase
     }
 
     /**
+     * Tests filesystem loader works with .twig files
+     * included by other templates.
+     *
+     * @return void
+     */
+    public function testChainedLoader()
+    {
+        $output = $this->view->render('test_include', false);
+        $this->assertSame('underscore_me', $output);
+    }
+
+    /**
      * Tests deprecated element and cell tags render.
      *
      * @return void

--- a/tests/test_app/templates/test_include.twig
+++ b/tests/test_app/templates/test_include.twig
@@ -1,0 +1,1 @@
+{{ include('simple.twig') }}


### PR DESCRIPTION
The TwigView loader only works with absolute paths from View so we add the default twig FilesystemLoader to handle the internal cases.

This should be easier than maintaining a more complex loader.