### PR TITLE
Manually search template paths for files loaded outside View functions

### DIFF
--- a/src/Twig/FileLoader.php
+++ b/src/Twig/FileLoader.php
@@ -100,12 +100,15 @@ class FileLoader implements LoaderInterface
         $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
 
         if ($plugin !== null) {
-            $path = $this->checkExtensions(Plugin::templatePath($plugin) . $name);
+            $templatePath = Plugin::templatePath($plugin);
+            $path = $this->checkExtensions($templatePath . $name);
             if ($path !== null) {
                 return $path;
             }
 
-            throw new LoaderError("Could not find template `{$name}` in plugin `{$plugin}`.");
+            $error = "Could not find template `{$name}` in plugin `{$plugin}` in these paths:\n\n"
+                . "- `{$templatePath}`\n";
+            throw new LoaderError($error);
         }
 
         foreach (App::path('templates') as $templatePath) {
@@ -115,7 +118,7 @@ class FileLoader implements LoaderInterface
             }
         }
 
-        $error = "Could not find template `{$name}`.\nThese paths were searched:\n\n";
+        $error = "Could not find template `{$name}` in these paths:\n\n";
         foreach (App::path('templates') as $templatePath) {
             $error .= "- `{$templatePath}`\n";
         }

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -151,25 +151,13 @@ class TwigView extends View
     }
 
     /**
-     * Gets the full path for template.
-     *
-     * @param string $name Template name
-     * @return string
-     * @throws \Cake\View\Exception\MissingTemplateException When template is not found
-     */
-    public function resolveTemplatePath(string $name): string
-    {
-        return $this->_getTemplateFileName($name);
-    }
-
-    /**
      * Creates the Twig LoaderInterface instance.
      *
      * @return \Twig\Loader\LoaderInterface
      */
     protected function createLoader(): LoaderInterface
     {
-        return new FileLoader($this);
+        return new FileLoader($this->extensions);
     }
 
     /**

--- a/tests/TestCase/Twig/FileLoaderTest.php
+++ b/tests/TestCase/Twig/FileLoaderTest.php
@@ -59,8 +59,9 @@ class FileLoaderTest extends TestCase
     public function testGetSourceNonExistingFile()
     {
         $this->expectException(LoaderError::class);
+        $this->expectExceptionMessage("Could not find template `missing` in plugin `TestTwigView`");
 
-        $this->loader->getSourceContext('TestTwigView.no_twig');
+        $this->loader->getSourceContext('TestTwigView.missing');
     }
 
     public function testGetCacheKey()

--- a/tests/TestCase/Twig/FileLoaderTest.php
+++ b/tests/TestCase/Twig/FileLoaderTest.php
@@ -20,7 +20,6 @@ namespace Cake\TwigView\Test\TestCase\Twig;
 
 use Cake\TestSuite\TestCase;
 use Cake\TwigView\Twig\FileLoader;
-use Cake\TwigView\View\TwigView;
 use Twig\Error\LoaderError;
 
 /**
@@ -39,7 +38,7 @@ class FileLoaderTest extends TestCase
 
         $this->loadPlugins(['TestTwigView']);
 
-        $this->loader = new FileLoader(new TwigView());
+        $this->loader = new FileLoader(['.twig']);
     }
 
     public function tearDown(): void
@@ -93,7 +92,12 @@ class FileLoaderTest extends TestCase
     public function testIsFreshNonExistingFile()
     {
         $this->expectException(LoaderError::class);
-
         $this->loader->isFresh(TMP . 'foobar' . time(), time());
+    }
+
+    public function testExistsNonExistingFile()
+    {
+        $exists = $this->loader->exists(TMP . 'foobar' . time(), time());
+        $this->assertSame(false, $exists);
     }
 }

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -170,6 +170,18 @@ class TwigViewTest extends TestCase
     }
 
     /**
+     * Tests extends loads templates from root templates paths.
+     *
+     * @return void
+     */
+    public function testTwigExtendsRootPath()
+    {
+        $view = new AppView(null, null, null, ['templatePath' => 'Blog']);
+        $output = $view->render('blog_with_extends');
+        $this->assertSame('base from subdir/base', $output);
+    }
+
+    /**
      * Tests deprecated element and cell tags render.
      *
      * @return void

--- a/tests/test_app/templates/Blog/blog_with_extends.twig
+++ b/tests/test_app/templates/Blog/blog_with_extends.twig
@@ -1,0 +1,1 @@
+{% extends 'subdir_with_base/base' %}

--- a/tests/test_app/templates/subdir_with_base/base.twig
+++ b/tests/test_app/templates/subdir_with_base/base.twig
@@ -1,0 +1,1 @@
+base from subdir/base


### PR DESCRIPTION
Trying to re-use the internal Twig template searching puts unwanted restrictions on file paths. When extending twig templates, we often have base templates in the root directory not in the Controller directory. View automatically sets the `templatePath` to the Controller name.

Always load twig templates relative to the root template paths.

This is the expected behavior coming from legacy TwigView as well. This was missed in unit tests because we don't build TwigView through `ViewBuilder` from a Controller which automatically add the config.