### PR TITLE
Added TwigAjaxView which mimics AjaxView in core

### DIFF
--- a/src/View/TwigAjaxView.php
+++ b/src/View/TwigAjaxView.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.3
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\TwigView\View;
+
+/**
+ * Wraps TwigView with ajax layout and ajax response type.
+ */
+class TwigAjaxView extends TwigView
+{
+    /**
+     * @inheritDoc
+     */
+    protected $layout = 'ajax';
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        $this->response = $this->response->withType('ajax');
+    }
+}

--- a/tests/TestCase/View/TwigAjaxViewTest.php
+++ b/tests/TestCase/View/TwigAjaxViewTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.3
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\TwigView\Test\TestCase;
+
+use Cake\Http\Response;
+use Cake\TestSuite\TestCase;
+use TestApp\View\AjaxView;
+
+/**
+ * Class TwigAjaxViewTest.
+ */
+class TwigAjaxViewTest extends TestCase
+{
+    /**
+     * @var \TestApp\View\AppView
+     */
+    protected $view;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->view = new AjaxView();
+    }
+
+    /**
+     * Tests TwigAjaxView configures ajax properly.
+     *
+     * @return void
+     */
+    public function testConfiguration()
+    {
+        $this->assertSame('ajax', $this->view->getLayout());
+        $this->assertEquals((new Response(['type' => 'ajax']))->getType(), $this->view->getResponse()->getType());
+    }
+}

--- a/tests/test_app/src/View/AjaxView.php
+++ b/tests/test_app/src/View/AjaxView.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.3
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace TestApp\View;
+
+use Cake\TwigView\View\TwigAjaxView;
+
+class AjaxView extends TwigAjaxView
+{
+    /**
+     * Initialization hook method.
+     *
+     * Loads the necessary helper and properly configures them.
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->loadHelper('TestSecond');
+    }
+
+    /**
+     * Clear internal Twig instances for testing.
+     *
+     * @return void
+     */
+    public static function destroyTwig(): void
+    {
+        static::$profile = null;
+        static::$twig = null;
+    }
+}


### PR DESCRIPTION
This allows users to create `AjaxView` in their app namespace without having to copying anything.

I configured the `Response` objects in `initialize()` so the response type is always set even if the view is constructed with a default response. The core cake `AjaxView` should do the same if this is committed.