### PR TITLE
Updated several filter wrappers.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,8 @@ parameters:
     level: 6
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
-    excludes_analyse:
-        - src/Shell/Task/TwigTemplateTask.php
+    bootstrapFiles:
+        - tests/bootstrap.php
     ignoreErrors:
         -
             message: "#^Constant CACHE not found\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,3 @@ parameters:
     checkGenericClassInNonGenericObjectType: false
     bootstrapFiles:
         - tests/bootstrap.php
-    ignoreErrors:
-        -
-            message: "#^Constant CACHE not found\\.$#"
-            count: 1
-            path: src/View/TwigView.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,11 +6,6 @@ parameters:
         - src/Shell/Task/TwigTemplateTask.php
     ignoreErrors:
         -
-            message: "#^Parameter \\#2 \\$callable of class Twig\\\\TwigFilter constructor expects \\(callable\\(\\)\\: mixed\\)\\|null, 'debug' given\\.$#"
-            count: 1
-            path: src/Twig/Extension/BasicExtension.php
-
-        -
             message: "#^Constant CACHE not found\\.$#"
             count: 1
             path: src/View/TwigView.php

--- a/src/Twig/Extension/BasicExtension.php
+++ b/src/Twig/Extension/BasicExtension.php
@@ -34,12 +34,36 @@ class BasicExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('debug', 'debug'),
-            new TwigFilter('pr', 'pr'),
+            new TwigFilter('debug', function () {
+                static $logged = false;
+                if (!$logged) {
+                    $logged = true;
+                    deprecationWarning('`debug` filter is deprecated, use `dump()` instead.');
+                }
+
+                return debug(...func_get_args());
+            }),
+            new TwigFilter('pr', function () {
+                static $logged = false;
+                if (!$logged) {
+                    $logged = true;
+                    deprecationWarning('`pr` filter is deprecated, use `dump()` instead.');
+                }
+
+                return pr(...func_get_args());
+            }),
             new TwigFilter('low', 'strtolower'),
             new TwigFilter('up', 'strtoupper'),
             new TwigFilter('env', 'env'),
-            new TwigFilter('count', 'count'),
+            new TwigFilter('count', function () {
+                static $logged = false;
+                if (!$logged) {
+                    $logged = true;
+                    deprecationWarning('`count` filter is deprecated, use `length` instead.');
+                }
+
+                return count(...func_get_args());
+            }),
             new TwigFilter('h', 'h'),
             new TwigFilter('null', function () {
                 return '';

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -37,7 +37,7 @@ class NumberExtension extends AbstractExtension
         return [
             new TwigFilter('toReadableSize', 'Cake\I18n\Number::toReadableSize'),
             new TwigFilter('toPercentage', 'Cake\I18n\Number::toPercentage'),
-            new TwigFilter('number_format', 'Cake\I18n\Number::format'),
+            new TwigFilter('cake_number_format', 'Cake\I18n\Number::format'),
             new TwigFilter('formatDelta', 'Cake\I18n\Number::formatDelta'),
             new TwigFilter('currency', 'Cake\I18n\Number::currency'),
         ];
@@ -51,7 +51,7 @@ class NumberExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('defaultCurrency', 'Cake\I18n\Number::defaultCurrency'),
+            new TwigFunction('defaultCurrency', 'Cake\I18n\Number::getDefaultCurrency'),
             new TwigFunction('number_formatter', 'Cake\I18n\Number::formatter'),
         ];
     }

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Cake\TwigView\Twig\Extension;
 
+use Cake\I18n\Number;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -52,7 +53,17 @@ class NumberExtension extends AbstractExtension
     {
         return [
             new TwigFunction('defaultCurrency', 'Cake\I18n\Number::getDefaultCurrency'),
-            new TwigFunction('number_formatter', 'Cake\I18n\Number::formatter'),
+            new TwigFunction('number_formatter', function () {
+                static $logged = false;
+                if (!$logged) {
+                    $logged = true;
+                    deprecationWarning(
+                        '`number_formatter()` function is deprecated, use `cake_number_format` filter instead.'
+                    );
+                }
+
+                return Number::formatter(...func_get_args());
+            }),
         ];
     }
 }

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -212,7 +212,10 @@ class TwigView extends View
 
         // Twig core extensions
         $twig->addExtension(new StringLoaderExtension());
-        $twig->addExtension(new DebugExtension());
+
+        if (Configure::read('debug', false)) {
+            $twig->addExtension(new DebugExtension());
+        }
 
         // CakePHP bridging extensions
         $twig->addExtension(new Extension\ArraysExtension());

--- a/tests/TestCase/Twig/Extension/BasicExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/BasicExtensionTest.php
@@ -28,40 +28,37 @@ class BasicExtensionTest extends AbstractExtensionTest
         parent::setUp();
     }
 
-    public function testFilterDebug()
+    public function testDeprecatedDebug()
     {
-        $string = 'abc';
         $callable = $this->getFilter('debug')->getCallable();
-        ob_start();
-        $result = call_user_func_array($callable, [$string, null, false]);
-        $output = ob_get_clean();
-        $this->assertSame('abc', $result);
-        $this->assertSame('
-########## DEBUG ##########
-\'abc\'
-###########################
-', $output);
+
+        $this->expectDeprecation();
+        call_user_func_array($callable, ['test']);
     }
 
-    public function testFilterPr()
+    public function testDeprecatedPr()
     {
-        $string = 'abc';
         $callable = $this->getFilter('pr')->getCallable();
-        ob_start();
-        $result = call_user_func_array($callable, [$string]);
-        $output = ob_get_clean();
-        $this->assertSame('abc', $result);
-        $this->assertSame('
-abc
 
-', $output);
+        $this->expectDeprecation();
+        call_user_func_array($callable, ['test']);
     }
 
-    public function testFilterCount()
+    public function testDeprecatedCount()
     {
-        $array = ['a', 'b', 'c'];
         $callable = $this->getFilter('count')->getCallable();
-        $result = call_user_func_array($callable, [$array]);
-        $this->assertSame(3, $result);
+
+        $this->expectDeprecation();
+        call_user_func_array($callable, ['test']);
+    }
+
+    public function testCount()
+    {
+        $this->deprecated(function () {
+            $array = ['a', 'b', 'c'];
+            $callable = $this->getFilter('count')->getCallable();
+            $result = call_user_func_array($callable, [$array]);
+            $this->assertSame(3, $result);
+        });
     }
 }


### PR DESCRIPTION
- Removed debug filters. Users can use `dump()` function
- Removed `count` filter. Users can use `length` filter.
- Moved `DebugExtension` loading to only debug mode
- Renamed `number_format` filter to `cake_number_format` to unhide twig filter
- Changed `defaultCurrency()` to call `Number::getDefaultCurrency()`