### PR TITLE
Improvements about type assertions and namespaces

### DIFF
--- a/tests/TestCase/Twig/Extension/AbstractExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/AbstractExtensionTest.php
@@ -42,7 +42,7 @@ abstract class AbstractExtensionTest extends TestCase
     public function testGetTokenParsers()
     {
         $tokenParsers = $this->extension->getTokenParsers();
-        $this->assertTrue(is_array($tokenParsers));
+        $this->assertIsArray($tokenParsers);
         foreach ($tokenParsers as $tokenParser) {
             $this->assertTrue($tokenParser instanceof TokenParserInterface);
         }
@@ -51,7 +51,7 @@ abstract class AbstractExtensionTest extends TestCase
     public function testGetNodeVisitors()
     {
         $nodeVisitors = $this->extension->getNodeVisitors();
-        $this->assertTrue(is_array($nodeVisitors));
+        $this->assertIsArray($nodeVisitors);
         foreach ($nodeVisitors as $nodeVisitor) {
             $this->assertInstanceOf('Twig_NodeVisitorInterface', $nodeVisitor);
         }
@@ -60,7 +60,7 @@ abstract class AbstractExtensionTest extends TestCase
     public function testGetFilters()
     {
         $filters = $this->extension->getFilters();
-        $this->assertTrue(is_array($filters));
+        $this->assertIsArray($filters);
         foreach ($filters as $filter) {
             $this->assertInstanceOf(TwigFilter::class, $filter);
         }

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
-namespace Cake\TwigView\Test\TestCase;
+namespace Cake\TwigView\Test\TestCase\View;
 
 use Cake\TestSuite\TestCase;
 use TestApp\View\AppView;


### PR DESCRIPTION
# Changed log

- Using the `assertIsArray` to assert result value type is `array`.
- Using the `Cake\TwigView\Test\TestCase\View;` namespace for `TwigViewTest` class.