### PR TITLE
Add layout tag for setting layout from template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '7.4'
         extensions: mbstring, intl
         coverage: none
 
@@ -109,7 +109,9 @@ jobs:
       run: vendor/bin/phpcs --report=checkstyle src/ tests/
 
     - name: Run psalm
+      if: success() || failure()
       run: vendor/bin/psalm.phar --output-format=github
 
     - name: Run phpstan
+      if: success() || failure()
       run: vendor/bin/phpstan.phar analyse --error-format=github

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             "@phpstan",
             "@psalm"
         ],
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12.54 psalm/phar:~4.1.1 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12.54 psalm/phar:~4.3.0 && mv composer.backup composer.json",
         "test": [
             "phpunit"
         ]

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.1.1@16bfbd9224698bd738c665f33039fade2a1a3977">
+<files psalm-version="4.3.1@2feba22a005a18bf31d4c7b9bdb9252c73897476">
   <file src="src/Twig/TokenParser/CellParser.php">
     <DeprecatedClass occurrences="1">
       <code>new CellNode($assign, $variable, $name, $data, $options, $token-&gt;getLine(), $this-&gt;getTag())</code>
@@ -17,6 +17,11 @@
     <InternalMethod occurrences="3">
       <code>parseExpression</code>
       <code>parseExpression</code>
+      <code>parseExpression</code>
+    </InternalMethod>
+  </file>
+  <file src="src/Twig/TokenParser/LayoutParser.php">
+    <InternalMethod occurrences="1">
       <code>parseExpression</code>
     </InternalMethod>
   </file>

--- a/src/Twig/Node/LayoutNode.php
+++ b/src/Twig/Node/LayoutNode.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\TwigView\Twig\Node;
+
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+use Twig\Node\NodeOutputInterface;
+
+/**
+ * layout tag node
+ */
+class LayoutNode extends Node implements NodeOutputInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param \Twig\Node\Expression\AbstractExpression $layout layout
+     * @param int $line Line number.
+     * @param string $tag Tag name.
+     */
+    public function __construct(AbstractExpression $layout, int $line = 0, ?string $tag = null)
+    {
+        parent::__construct(['layout' => $layout], [], $line, $tag);
+    }
+
+    /**
+     * Compile tag.
+     *
+     * @param \Twig\Compiler $compiler Compiler.
+     * @return void
+     */
+    public function compile(Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write('$context[\'_view\']->setLayout(')
+            ->subcompile($this->getNode('layout'))
+            ->raw(");\n");
+    }
+}

--- a/src/Twig/TokenParser/LayoutParser.php
+++ b/src/Twig/TokenParser/LayoutParser.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\TwigView\Twig\TokenParser;
+
+use Cake\TwigView\Twig\Node\LayoutNode;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * layout tag parser
+ */
+class LayoutParser extends AbstractTokenParser
+{
+    /**
+     * Parse token.
+     *
+     * @param \Twig\Token $token Token.
+     * @return \Twig\Node\Node
+     */
+    public function parse(Token $token): Node
+    {
+        $parser = $this->parser;
+        $stream = $parser->getStream();
+
+        $layout = $parser->getExpressionParser()->parseExpression();
+        $stream->expect(\Twig\Token::BLOCK_END_TYPE);
+
+        return new LayoutNode($layout, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * Tag name.
+     *
+     * @return string
+     */
+    public function getTag(): string
+    {
+        return 'layout';
+    }
+}

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -195,6 +195,7 @@ class TwigView extends View
      */
     protected function initializeTokenParser(): void
     {
+        $this->getTwig()->addTokenParser(new TokenParser\LayoutParser());
         $this->getTwig()->addTokenParser(new TokenParser\CellParser());
         $this->getTwig()->addTokenParser(new TokenParser\ElementParser());
     }

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -78,7 +78,7 @@ class TwigViewTest extends TestCase
     }
 
     /**
-     * Test rendering template with view block assignment
+     * Test rendering template with view block assignment.
      *
      * @return void
      */
@@ -87,6 +87,18 @@ class TwigViewTest extends TestCase
         $output = $this->view->render('Blog/with_extra_block', 'with_extra_block');
 
         $this->assertSame("main content\nextra content", $output);
+    }
+
+    /**
+     * Tests setting layout from template.
+     *
+     * @return void
+     */
+    public function testLayoutFromTemplate()
+    {
+        $output = $this->view->render('set_layout');
+
+        $this->assertSame("custom\nset layout", $output);
     }
 
     public function testRenderWithPluginElement()

--- a/tests/test_app/templates/layout/custom.twig
+++ b/tests/test_app/templates/layout/custom.twig
@@ -1,0 +1,2 @@
+custom
+{{ fetch('content') }}

--- a/tests/test_app/templates/set_layout.twig
+++ b/tests/test_app/templates/set_layout.twig
@@ -1,0 +1,3 @@
+{% set custom_layout = 'custom' %}
+{% layout custom_layout %}
+set layout


### PR DESCRIPTION
This allows setting the layout from view template similar to how they are done in default cake view templates. The layout is permanently set when set through the template.

Previously, you had to use a `{% do ... %}` work-around, but this is not very obvious since the `_view` global variable cannot modify protected members.

Example:
```twig
{% layout 'Error' %}
```