### PR TITLE
Deprecate low and up filters

### DIFF
--- a/src/Twig/Extension/BasicExtension.php
+++ b/src/Twig/Extension/BasicExtension.php
@@ -52,8 +52,24 @@ class BasicExtension extends AbstractExtension
 
                 return pr(...func_get_args());
             }),
-            new TwigFilter('low', 'strtolower'),
-            new TwigFilter('up', 'strtoupper'),
+            new TwigFilter('low', function () {
+                static $logged = false;
+                if (!$logged) {
+                    $logged = true;
+                    deprecationWarning('`low` filter is deprecated, use lower` instead.');
+                }
+
+                return strtolower(...func_get_args());
+            }),
+            new TwigFilter('up', function () {
+                static $logged = false;
+                if (!$logged) {
+                    $logged = true;
+                    deprecationWarning('`up` filter is deprecated, use `upper` instead.');
+                }
+
+                return strtoupper(...func_get_args());
+            }),
             new TwigFilter('env', 'env'),
             new TwigFilter('count', function () {
                 static $logged = false;

--- a/src/Twig/Extension/BasicExtension.php
+++ b/src/Twig/Extension/BasicExtension.php
@@ -56,7 +56,7 @@ class BasicExtension extends AbstractExtension
                 static $logged = false;
                 if (!$logged) {
                     $logged = true;
-                    deprecationWarning('`low` filter is deprecated, use lower` instead.');
+                    deprecationWarning('`low` filter is deprecated, use `lower` instead.');
                 }
 
                 return strtolower(...func_get_args());

--- a/tests/TestCase/Twig/Extension/BasicExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/BasicExtensionTest.php
@@ -44,6 +44,22 @@ class BasicExtensionTest extends AbstractExtensionTest
         call_user_func_array($callable, ['test']);
     }
 
+    public function testDeprecatedLow()
+    {
+        $this->deprecated(function () {
+            $callable = $this->getFilter('low')->getCallable();
+            $this->assertSame('test', call_user_func_array($callable, ['TEST']));
+        });
+    }
+
+    public function testDeprecatedUp()
+    {
+        $this->deprecated(function () {
+            $callable = $this->getFilter('up')->getCallable();
+            $this->assertSame('TEST', call_user_func_array($callable, ['test']));
+        });
+    }
+
     public function testDeprecatedCount()
     {
         $callable = $this->getFilter('count')->getCallable();


### PR DESCRIPTION
There are already `lower` and `upper` filters in Twig.