### PR TITLE
Add shim for date filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "cakephp/cakephp": "^5.0.0",
         "jasny/twig-extensions": "^1.3",
         "twig/markdown-extra": "^3.0",
-        "twig/twig": "^3.4"
+        "twig/twig": "^3.10.3"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",

--- a/src/Twig/Extension/TimeExtension.php
+++ b/src/Twig/Extension/TimeExtension.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Cake\TwigView\Twig\Extension;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
 use Cake\I18n\DateTime;
 use DateInterval;
@@ -70,12 +71,12 @@ class TimeExtension extends AbstractExtension
      *
      * Includes shims for \Chronos\ChronosDate as Twig doesn't.
      *
-     * @param \Chronos\ChronosDate|\DateTimeInterface|\DateInterval|string $date The date to format.
+     * @param mixed $date The date to format.
      * @param ?string $format The format to use, null to use the default.
      * @param \DateTimeZone|string|false|null $timezone The target timezone, null to use system.
      */
     public function formatDate(
-        ChronosDate|DateTimeInterface|DateInterval|string $date,
+        mixed $date,
         ?string $format = null,
         DateTimeZone|string|false|null $timezone = null
     ): string {
@@ -84,6 +85,9 @@ class TimeExtension extends AbstractExtension
         }
         if ($date instanceof ChronosDate) {
             $date = $date->toDateString();
+        }
+        if ($date instanceof Chronos) {
+            $date = $date->toIso8601String();
         }
 
         return $this->coreExt->formatDate($date, $format, $timezone);

--- a/src/Twig/Extension/TimeExtension.php
+++ b/src/Twig/Extension/TimeExtension.php
@@ -21,8 +21,6 @@ namespace Cake\TwigView\Twig\Extension;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
 use Cake\I18n\DateTime;
-use DateInterval;
-use DateTimeInterface;
 use DateTimeZone;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;

--- a/src/Twig/Extension/TimeExtension.php
+++ b/src/Twig/Extension/TimeExtension.php
@@ -83,7 +83,7 @@ class TimeExtension extends AbstractExtension
             $this->coreExt = new CoreExtension();
         }
         if ($date instanceof ChronosDate) {
-            $date = $date->toDateTimeImmutable();
+            $date = $date->toDateString();
         }
 
         return $this->coreExt->formatDate($date, $format, $timezone);

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -21,6 +21,7 @@ namespace Cake\TwigView\Test\TestCase\View;
 use Cake\Core\Configure;
 use Cake\I18n\Date;
 use Cake\I18n\DateTime;
+use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use TestApp\View\AppView;
 use Twig\Error\RuntimeError;
@@ -144,10 +145,15 @@ class TwigViewTest extends TestCase
      */
     public function testTwigDateFormat()
     {
+        $restore = I18n::getLocale();
+        I18n::setLocale('fr');
+
         $this->view->set('date', new Date('2024-06-24'));
         $this->view->set('datetime', new DateTime('2024-06-24 12:13:14'));
 
         $output = $this->view->render('date_format', false);
+        I18n::setLocale($restore);
+
         $expected = <<<TEXT
 Date: 2024/06/24
 Datetime: 2024/06/24 12:13:14

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -139,7 +139,6 @@ class TwigViewTest extends TestCase
         $this->assertSame($this->view->getTwig(), $cell->createView(AppView::class)->getTwig());
     }
 
-
     /**
      * Test that Cake date/time objects are formatted correctly
      */

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 namespace Cake\TwigView\Test\TestCase\View;
 
 use Cake\Core\Configure;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use TestApp\View\AppView;
 use Twig\Error\RuntimeError;
@@ -134,6 +136,23 @@ class TwigViewTest extends TestCase
     {
         $cell = $this->view->cell('Test');
         $this->assertSame($this->view->getTwig(), $cell->createView(AppView::class)->getTwig());
+    }
+
+
+    /**
+     * Test that Cake date/time objects are formatted correctly
+     */
+    public function testTwigDateFormat()
+    {
+        $this->view->set('date', new Date('2024-06-24'));
+        $this->view->set('datetime', new DateTime('2024-06-24 12:13:14'));
+
+        $output = $this->view->render('date_format', false);
+        $expected = <<<TEXT
+Date: 2024/06/24
+Datetime: 2024/06/24 12:13:14
+TEXT;
+        $this->assertSame($expected, $output);
     }
 
     /**

--- a/tests/test_app/templates/date_format.twig
+++ b/tests/test_app/templates/date_format.twig
@@ -1,0 +1,2 @@
+Date: {{ date|date('Y/m/d') }}
+Datetime: {{ datetime|date('Y/m/d H:i:s') }}


### PR DESCRIPTION
Handle Date values so that we maintain compatibility with twig
templates and date objects.

Fixes https://github.com/cakephp/twig-view/issues/97