### PR TITLE
Add configurable underscore command naming

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "source": "https://github.com/cakephp/twig-view"
     },
     "require": {
+        "php": ">=8.1",
         "cakephp/cakephp": "^5.0.0",
         "jasny/twig-extensions": "^1.3",
         "twig/markdown-extra": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cakephp/debug_kit": "^5.0",
         "michelf/php-markdown": "^1.9",
         "mikey179/vfsstream": "^1.6.10",
-        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.0"
     },
     "conflict": {
         "wyrihaximus/twig-view": "*"
@@ -50,8 +50,8 @@
         }
     },
     "scripts": {
-        "cs-check": "phpcs --colors --parallel=16 -p src/ tests/",
-        "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
+        "cs-check": "phpcs --colors --parallel=16 -p",
+        "cs-fix": "phpcbf --colors --parallel=16 -p",
         "phpstan": "tools/phpstan analyse",
         "stan": "@phpstan",
         "phpstan-baseline": "tools/phpstan --generate-baseline",

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * CakePHP TwigView Plugin - Example Configuration
+ *
+ * Copy the relevant settings to your application's config/app.php or config/app_local.php.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+return [
+    /**
+     * TwigView Plugin Configuration
+     *
+     * These settings control the behavior of the TwigView plugin.
+     */
+    'TwigView' => [
+        /**
+         * Use underscore command names.
+         *
+         * When `true`, registers `twig_view compile` (with underscore).
+         * When `false` or not set, registers `twig-view compile` (deprecated, with hyphen).
+         *
+         * Upgrade path:
+         * 1. Update your scripts/CI to use `twig_view compile`
+         * 2. Set this to `true`
+         */
+        'useUnderscoreCommands' => true,
+    ],
+];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="TwigView">
+    <file>src/</file>
+    <file>tests/</file>
+
     <rule ref="CakePHP"/>
 </ruleset>

--- a/src/TwigViewPlugin.php
+++ b/src/TwigViewPlugin.php
@@ -20,6 +20,7 @@ namespace Cake\TwigView;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
 use Cake\TwigView\Command\CompileCommand;
 
 /**
@@ -46,7 +47,12 @@ class TwigViewPlugin extends BasePlugin
      */
     public function console(CommandCollection $commands): CommandCollection
     {
-        $commands->add('twig-view compile', CompileCommand::class);
+        if (Configure::read('TwigView.useUnderscoreCommands')) {
+            $commands->add('twig_view compile', CompileCommand::class);
+        } else {
+            // Deprecated: use `'TwigView.useUnderscoreCommands' => true` to switch to `twig_view compile`
+            $commands->add('twig-view compile', CompileCommand::class);
+        }
 
         return $commands;
     }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/19086

  Unfortunately, CakePHP's CommandCollection doesn't have a built-in mechanism to hide specific command aliases from the list - the hidden property on Command
   classes applies to the command itself regardless of which name it's invoked with. Both will appear in bin/cake output, but both will work identically.
   
   So we need a feature flag switch

## Summary
- Add `TwigView.useUnderscoreCommands` config option for command naming style
- When `true`: registers `twig_view compile` (new underscore style)
- When `false`/unset: registers `twig-view compile` (deprecated hyphen style)
- Add `config/app.example.php` documenting available options
- Add PHPUnit 12 support

## Upgrade path
1. Update scripts/CI to use `twig_view compile`
2. Set `'TwigView.useUnderscoreCommands' => true` in config


We should be able to release this as a minor