### PR TITLE
Add missing command description for compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This plugin allows you to use the [Twig Templating Language](https://twig.symfony.com/doc/) for your views.
 
-It provides wrappers for common View opertions and many helpful extensions that expose CakePHP functions and `jasny/twig-extensions` helpers.
+It provides wrappers for common View operations and many helpful extensions that expose CakePHP functions and `jasny/twig-extensions` helpers.
 
 ## Installation
 

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -19,6 +19,14 @@ class CompileCommand extends BaseCommand
     protected TwigView $twigView;
 
     /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'Compile Twig templates for caching.';
+    }
+
+    /**
      * @inheritDoc
      */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser


### PR DESCRIPTION
## Summary
- Adds missing description for the `twig-view compile` command so it appears in the CLI command listing.