### PR TITLE
update stan and require secure twig version

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="2.1.55" installed="2.1.55" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="2.2.1" installed="2.2.1" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "cakephp/cakephp": "^5.0.0",
         "jasny/twig-extensions": "^1.3",
         "twig/markdown-extra": "^3.0",
-        "twig/twig": "^3.11.1"
+        "twig/twig": "^3.27.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",


### PR DESCRIPTION
As you all know Twig had quite the list of security issues released last week, so we should at least adjust our minimum version requirement to the currently fixed minimum version.

https://symfony.com/blog/twig-3-26-0-released
https://symfony.com/blog/twig-3-27-0-released