### PR TITLE
Fix deserialization of untrusted data weakness

### DIFF
--- a/src/Twig/Extension/UtilsExtension.php
+++ b/src/Twig/Extension/UtilsExtension.php
@@ -20,6 +20,7 @@ namespace Cake\TwigView\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Class UtilsExtension.
@@ -34,8 +35,16 @@ class UtilsExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('serialize', 'serialize'),
-            new TwigFilter('unserialize', 'unserialize'),
+            new TwigFilter('serialize', function (string $value): mixed {
+                deprecationWarning('5.0.2', 'Usage of serialize in templates deprecated.');
+
+                return serialize($value);
+            }),
+            new TwigFilter('unserialize', function (string $value): mixed {
+                deprecationWarning('5.0.2', 'unserialize is deprecated. Its usage creates arbitrary object deserialization issues');
+
+                return unserialize($value, ['allowed_classes' => false]);
+            }),
             new TwigFilter('md5', 'md5'),
             new TwigFilter('base64_encode', 'base64_encode'),
             new TwigFilter('base64_decode', 'base64_decode'),

--- a/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
@@ -42,7 +42,7 @@ class UtilsExtensionTest extends AbstractExtensionTest
 
         // 1) Object payload: does a gadget's magic method run?
         GadgetMarker::$woken = false;
-        $this->deprecated(function () use ($twig) {
+        $this->deprecated(function () use ($twig): void {
             $twig->render('object', ['payload' => serialize(new GadgetMarker())]);
             $this->assertFalse(GadgetMarker::$woken, 'Should not have modified GadgetMarker');
 

--- a/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
@@ -33,7 +33,7 @@ class UtilsExtensionTest extends AbstractExtensionTest
 
     public function testUnserializePreventObject(): void
     {
-        $this->skipIf(version_compare(PHP_VERSION, '8.3.0', '<'), 'Requires PHP8.3 or higher');
+        $this->skipIf(PHP_VERSION_ID < 80300, 'Requires PHP8.3 or higher');
 
         $twig = new Environment(new ArrayLoader([
             // {% set %} so we exercise the filter without stringifying the result.

--- a/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * Copyright (c) 2014 Cees-Jan Kiewiet
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\TwigView\Test\TestCase\Twig\Extension;
+
+use Cake\TwigView\Twig\Extension\UtilsExtension;
+use TestApp\GadgetMarker;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class UtilsExtensionTest extends AbstractExtensionTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension = new UtilsExtension();
+    }
+
+    public function testUnserializePreventObject(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            // {% set %} so we exercise the filter without stringifying the result.
+            'object' => '{% set _ = payload|unserialize %}(rendered)',
+            'array' => '{{ (payload|unserialize)["role"] }}',
+        ]));
+        $twig->addExtension(new UtilsExtension());
+
+        // 1) Object payload: does a gadget's magic method run?
+        GadgetMarker::$woken = false;
+        $this->deprecated(function () use ($twig) {
+            $twig->render('object', ['payload' => serialize(new GadgetMarker())]);
+            $this->assertFalse(GadgetMarker::$woken, 'Should not have modified GadgetMarker');
+
+            $out = $twig->render('array', ['payload' => serialize(['role' => 'editor'])]);
+            $this->assertStringContainsString('editor', $out);
+        });
+    }
+}

--- a/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
+++ b/tests/TestCase/Twig/Extension/UtilsExtensionTest.php
@@ -33,6 +33,8 @@ class UtilsExtensionTest extends AbstractExtensionTest
 
     public function testUnserializePreventObject(): void
     {
+        $this->skipIf(version_compare(PHP_VERSION, '8.3.0', '<'), 'Requires PHP8.3 or higher');
+
         $twig = new Environment(new ArrayLoader([
             // {% set %} so we exercise the filter without stringifying the result.
             'object' => '{% set _ = payload|unserialize %}(rendered)',

--- a/tests/test_app/src/GadgetMarker.php
+++ b/tests/test_app/src/GadgetMarker.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp;
+
+class GadgetMarker
+{
+    public static bool $woken = false;
+
+    public function __wakeup(): void
+    {
+        self::$woken = true;
+        echo "  [!] GadgetMarker::__wakeup fired during unserialize (object injection)\n";
+    }
+}


### PR DESCRIPTION
The unserialize filter has a weakness to arbitrary class usage which can be combined with user input to create unserialization gadgets which are used in RCE vulnerability chains.

I've also chosen to deprecate these functions. I see no reason to continue having them when they have so many sharp edges. Applications relying on these features, can add their own filters.

Thanks to Volker Dusch and the PHP Ecosystem security team for reporting this.